### PR TITLE
Switch map tiles to smooth upscaling 

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
@@ -132,7 +132,12 @@ public class TileSource {
                                                          final String... baseUrls) {
     final boolean highDensity = Screen.isHighDensity(context);
     final int tileSize = highDensity ? 512 : 256;
-    final String tileSuffix = highDensity ? "@2x.png" : ".png";
+
+    // It's possible to use "@2x.png" to get upscaled tiles. However, currently, Cyclestreets
+    // tile server currently only performs nearest-neighbor upscaling, so it's better to perform
+    // bilinear scaling on the device.
+    final String tileSuffix = ".png";
+
     return createXYTileSource(name, aResourceId, tileSize, tileSuffix, baseUrls);
   } // createDensityAwareTileSource
 

--- a/libraries/cyclestreets-view/src/main/java/org/mapsforge/android/maps/MapsforgeOSMTileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/org/mapsforge/android/maps/MapsforgeOSMTileSource.java
@@ -63,7 +63,7 @@ public class MapsforgeOSMTileSource implements ITileSource {
     jobParameters_ = new JobParameters(new RenderTheme(), DEFAULT_TEXT_SCALE);
     debugSettings_ = new DebugSettings(false, false, false);
 
-    tileSize_ = upSize ? 512 : 256;
+    tileSize_ = upSize ? 2 * Tile.TILE_SIZE : Tile.TILE_SIZE;
   } // MapsforgeOSMTileSource
   
   public void setMapFile(final String mapFile) {
@@ -104,7 +104,7 @@ public class MapsforgeOSMTileSource implements ITileSource {
     boolean success = mapGenerator_.executeJob(mapGeneratorJob, tileBitmap);
 
     if (tileSize_ != Tile.TILE_SIZE)
-      tileBitmap = Bitmap.createScaledBitmap(tileBitmap, tileSize_, tileSize_, false);
+      tileBitmap = Bitmap.createScaledBitmap(tileBitmap, tileSize_, tileSize_, true);
 
     return success ? new ExpirableBitmapDrawable(tileBitmap) : null;
   } // getDrawable


### PR DESCRIPTION
On high-density screens (https://github.com/cyclestreets/android/issues/68), render map tiles with smooth upscaling, rather than nearest neighbor.