### PR TITLE
Fixing build warnings etc.

### DIFF
--- a/cyclestreets.vNext/src/main/java/net/cyclestreets/BlogFragment.java
+++ b/cyclestreets.vNext/src/main/java/net/cyclestreets/BlogFragment.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 
 import net.cyclestreets.api.Blog;
 

--- a/cyclestreets.vNext/src/main/java/net/cyclestreets/CycleStreets.java
+++ b/cyclestreets.vNext/src/main/java/net/cyclestreets/CycleStreets.java
@@ -2,18 +2,6 @@ package net.cyclestreets;
 
 import android.os.Bundle;
 
-import net.cyclestreets.ElevationProfileFragment;
-import net.cyclestreets.ItineraryFragment;
-import net.cyclestreets.MainNavDrawerActivity;
-import net.cyclestreets.MainSupport;
-import net.cyclestreets.PhotoMapFragment;
-import net.cyclestreets.PhotoUploadFragment;
-import net.cyclestreets.RouteAvailablePageStatus;
-import net.cyclestreets.RouteMapActivity;
-import net.cyclestreets.RouteMapFragment;
-import net.cyclestreets.WebPageFragment;
-import net.cyclestreets.api.Blog;
-
 public class CycleStreets extends MainNavDrawerActivity
                           implements RouteMapActivity {
   @Override

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/RoutePlans.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/RoutePlans.java
@@ -11,7 +11,7 @@ public class RoutePlans {
       PLAN_QUIETEST, PLAN_BALANCED, PLAN_FASTEST, PLAN_SHORTEST
   };
 
-  public final static String[] allPlans() {
+  public static String[] allPlans() {
     return Plans;
   } // plans
 } // RoutePlans

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiCallCache.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiCallCache.java
@@ -16,7 +16,7 @@ import android.content.Context;
 public class ApiCallCache
 {
   private final Context context_;
-  private final Map<Integer, Long> daysToMs = new HashMap<Integer, Long>();
+  private final Map<Integer, Long> daysToMs = new HashMap<>();
   private static final int DEFAULT_BUFFER_SIZE = 40960;
   
   ApiCallCache(final Context context)

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.java
@@ -460,14 +460,14 @@ public class ApiClient
     return factory.read(result);
   } // loadRaw
 
-   private static <T> Map<String, T> argMap(String path, T... args) {
-     Map<String, T> params = new HashMap<>();
-     for (int i = 0; i != args.length; i+=2)
-       params.put((String)args[i], args[i+1]);
+  private static <T> Map<String, T> argMap(String path, T... args) {
+    Map<String, T> params = new HashMap<>();
+    for (int i = 0; i != args.length; i+=2)
+      params.put((String)args[i], args[i+1]);
      
-     if (customiser_ != null)
-       customiser_.customise(path, params);
+    if (customiser_ != null)
+      customiser_.customise(path, params);
      
-     return params;
-   } // argMap
+    return params;
+  } // argMap
 } // ApiClient

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Blog.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Blog.java
@@ -23,7 +23,7 @@ public class Blog
   
   private Blog()
   {
-    entries_ = new ArrayList<BlogEntry>();
+    entries_ = new ArrayList<>();
   } // Blog
   
   public boolean isNull() 

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Factory.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Factory.java
@@ -15,7 +15,7 @@ import net.cyclestreets.api.json.JsonReader;
 import net.cyclestreets.api.json.JsonRootHandler;
 
 interface Factory<T> {
-  public T read(final byte[] xml);
+  T read(final byte[] xml);
 
   abstract class JsonProcessor<T> implements Factory<T> {
     public T read(final byte[] json) {

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/GeoLiveAdapter.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/GeoLiveAdapter.java
@@ -93,7 +93,7 @@ public class GeoLiveAdapter extends GeoAdapter
     @Override
     protected FilterResults performFiltering(CharSequence cs)
     {
-      final List<GeoPlace> list = new ArrayList<GeoPlace>();
+      final List<GeoPlace> list = new ArrayList<>();
       
       if (cs != null)
       {
@@ -138,7 +138,7 @@ public class GeoLiveAdapter extends GeoAdapter
         return;
 			
       final String match = (PREFS_GEO_NAME_PREFIX + cs).toLowerCase();
-      final Set<String> sortedKeys = new TreeSet<String>(prefs.getAll().keySet());
+      final Set<String> sortedKeys = new TreeSet<>(prefs.getAll().keySet());
 		
       for (final String s: sortedKeys)
       {		

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/GeoPlaces.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/GeoPlaces.java
@@ -22,7 +22,7 @@ public class GeoPlaces implements Iterable<GeoPlace>
   
   private GeoPlaces()
   {
-    places_ = new ArrayList<GeoPlace>();
+    places_ = new ArrayList<>();
   } // GeoPlaces
   
   private void add(final GeoPlace place) { places_.add(place); }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POICategory.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POICategory.java
@@ -5,15 +5,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.osmdroid.api.IGeoPoint;
-import org.xml.sax.Attributes;
-import org.xml.sax.ContentHandler;
 
 import android.graphics.drawable.Drawable;
-import android.sax.Element;
-import android.sax.EndElementListener;
-import android.sax.EndTextElementListener;
-import android.sax.RootElement;
-import android.sax.StartElementListener;
 
 import net.cyclestreets.api.json.JsonArrayHandler;
 import net.cyclestreets.api.json.JsonObjectHandler;

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/PhotoMarkers.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/PhotoMarkers.java
@@ -1,15 +1,12 @@
 package net.cyclestreets.api;
 
 import net.cyclestreets.core.R;
-import net.cyclestreets.util.MapFactory;
 
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.util.TypedValue;
 
 import java.io.InputStream;
 import java.util.HashMap;

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/PhotomapCategories.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/PhotomapCategories.java
@@ -20,8 +20,8 @@ public class PhotomapCategories
 {
   static private PhotomapCategories loaded_;
 
-  private List<PhotomapCategory> categories_ = new ArrayList<PhotomapCategory>();
-  private List<PhotomapCategory> metaCategories_ = new ArrayList<PhotomapCategory>();
+  private List<PhotomapCategory> categories_ = new ArrayList<>();
+  private List<PhotomapCategory> metaCategories_ = new ArrayList<>();
 
   public List<PhotomapCategory> categories() { return categories_; }
   public List<PhotomapCategory> metaCategories() { return metaCategories_; }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/json/JsonReader.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/json/JsonReader.java
@@ -275,7 +275,7 @@ public final class JsonReader implements Closeable {
       throw new IllegalStateException("Expected a boolean but was " + token);
     }
 
-    boolean result = (value == TRUE);
+    boolean result = (TRUE.equals(value));
     advance();
     return result;
   }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/routing/Waypoints.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/routing/Waypoints.java
@@ -21,12 +21,12 @@ public class Waypoints implements Iterable<IGeoPoint>
   
   public Waypoints() 
   {
-    waypoints_ = new ArrayList<IGeoPoint>();
+    waypoints_ = new ArrayList<>();
   } // Waypoints
   
   private Waypoints(final IGeoPoint from, final IGeoPoint to)
   {
-    waypoints_ = new ArrayList<IGeoPoint>();
+    waypoints_ = new ArrayList<>();
     waypoints_.add(from);
     waypoints_.add(to);
   } // Waypoints
@@ -55,7 +55,7 @@ public class Waypoints implements Iterable<IGeoPoint>
   
   public Waypoints reversed() 
   {
-    final List<IGeoPoint> points = new ArrayList<IGeoPoint>(waypoints_);
+    final List<IGeoPoint> points = new ArrayList<>(waypoints_);
     Collections.reverse(points);
     return new Waypoints(points);
   } // reversed

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Base64.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Base64.java
@@ -409,7 +409,7 @@ public class Base64
      * in which case one of them will be picked, though there is
      * no guarantee as to which one will be picked.
      */
-    private final static byte[] getAlphabet( int options ) {
+    private static byte[] getAlphabet( int options ) {
         if ((options & URL_SAFE) == URL_SAFE) {
             return _URL_SAFE_ALPHABET;
         } else if ((options & ORDERED) == ORDERED) {
@@ -427,7 +427,7 @@ public class Base64
      * in which case one of them will be picked, though there is
      * no guarantee as to which one will be picked.
      */
-    private final static byte[] getDecodabet( int options ) {
+    private static byte[] getDecodabet( int options ) {
         if( (options & URL_SAFE) == URL_SAFE) {
             return _URL_SAFE_DECODABET;
         } else if ((options & ORDERED) == ORDERED) {
@@ -1371,12 +1371,10 @@ public class Base64
         
             obj = ois.readObject();
         }   // end try
-        catch( java.io.IOException e ) {
+        catch( java.io.IOException | ClassNotFoundException e ) {
             throw e;    // Catch and throw in order to execute finally{}
         }   // end catch
-        catch( java.lang.ClassNotFoundException e ) {
-            throw e;    // Catch and throw in order to execute finally{}
-        }   // end catch
+        // end catch
         finally {
             try{ bais.close(); } catch( Exception e ){}
             try{ ois.close();  } catch( Exception e ){}

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Collections.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Collections.java
@@ -7,9 +7,9 @@ import java.util.Iterator;
 
 public class Collections
 {
-  static public interface MapBuilder<K,V> extends Map<K, V>
+  public interface MapBuilder<K,V> extends Map<K, V>
   {
-    public MapBuilder<K, V> map(K key, V v);
+    MapBuilder<K, V> map(K key, V v);
   } // interface MapBuilder
 
   static public <K, V> MapBuilder<K,V> map(K key, V value)

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/ListFactory.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/ListFactory.java
@@ -1,5 +1,6 @@
 package net.cyclestreets.util;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
@@ -8,17 +9,15 @@ public class ListFactory<T>
 {
   static public <T> List<T> list(final T... values)
   {
-    final List<T> l = new ArrayList<T>();
-    
-    for(final T o : values)
-      l.add(o);
+    final List<T> l = new ArrayList<>();
+    Collections.addAll(l, values);
 
     return l;
   } // list
 
   static public <T> List<T> list(final Iterator<T> values)
   {
-    final List<T> l = new ArrayList<T>();
+    final List<T> l = new ArrayList<>();
     
     while(values.hasNext())
       l.add(values.next());

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/MapFactory.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/MapFactory.java
@@ -11,7 +11,7 @@ public class MapFactory<K, V>
 {
   static public <K, V> MapBuilder<K, V> map(K key, V value)
   {
-	final Builder<K, V> builder = new Builder<K, V>();
+	final Builder<K, V> builder = new Builder<>();
 	return builder.map(key, value);
   } // map
 
@@ -21,7 +21,7 @@ public class MapFactory<K, V>
 		
 	private Builder() 
 	{
-	  backing_ = new HashMap<K, V>();
+	  backing_ = new HashMap<>();
 	} // Builder
 
 	public MapBuilder<K, V> map(K key, V value)

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.java
@@ -71,7 +71,7 @@ public class CycleMapFragment extends Fragment implements Undoable
   @Override
   public void onPrepareOptionsMenu(final Menu menu)
   {
-    if (forceMenuRebuild_ == true) {
+    if (forceMenuRebuild_) {
       forceMenuRebuild_ = false;
       menu.clear();
       onCreateOptionsMenu(menu, getActivity().getMenuInflater());

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/FindPlace.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/FindPlace.java
@@ -4,24 +4,16 @@ import net.cyclestreets.fragments.R;
 
 import net.cyclestreets.api.GeoPlace;
 
-import net.cyclestreets.util.GeoIntent;
 import net.cyclestreets.util.MessageBox;
 import net.cyclestreets.views.PlaceView;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
-import android.view.Gravity;
 import android.view.View;
-import android.widget.Button;
 import android.widget.Toast;
-import android.widget.RelativeLayout.LayoutParams;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.util.BoundingBoxE6;
-import org.osmdroid.util.GeoPoint;
 
 public class FindPlace {
   public interface Listener {

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/ItineraryFragment.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/ItineraryFragment.java
@@ -1,15 +1,6 @@
 package net.cyclestreets;
 
-import net.cyclestreets.api.DistanceFormatter;
-import net.cyclestreets.fragments.R;
-
-import net.cyclestreets.routing.Journey;
-import net.cyclestreets.routing.Route;
-import net.cyclestreets.routing.Segment;
-import net.cyclestreets.routing.Waypoints;
-
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -22,6 +13,12 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import net.cyclestreets.api.DistanceFormatter;
+import net.cyclestreets.fragments.R;
+import net.cyclestreets.routing.Journey;
+import net.cyclestreets.routing.Route;
+import net.cyclestreets.routing.Segment;
+import net.cyclestreets.routing.Waypoints;
 import net.cyclestreets.util.Theme;
 import net.cyclestreets.util.TurnIcons;
 

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/LocationsFragment.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/LocationsFragment.java
@@ -2,7 +2,6 @@ package net.cyclestreets;
 
 import android.content.Context;
 import android.content.Intent;
-import android.location.Location;
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
 import android.view.ContextMenu;
@@ -20,7 +19,6 @@ import android.widget.TextView;
 import net.cyclestreets.content.LocationDatabase;
 import net.cyclestreets.content.SavedLocation;
 import net.cyclestreets.fragments.R;
-import net.cyclestreets.routing.Segment;
 
 import java.util.List;
 

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainTabbedActivity.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainTabbedActivity.java
@@ -28,7 +28,7 @@ import android.widget.TabHost.TabSpec;
 public abstract class MainTabbedActivity extends FragmentActivity implements OnTabChangeListener, TabHost.TabContentFactory
 {
   private TabHost tabHost_;
-  private final Map<String, TabInfo> tabs_ = new HashMap<String, TabInfo>();
+  private final Map<String, TabInfo> tabs_ = new HashMap<>();
   private TabInfo lastTab_;
 
 	public void onCreate(final Bundle savedInstanceState)

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/PhotoUploadFragment.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/PhotoUploadFragment.java
@@ -71,7 +71,7 @@ public class PhotoUploadFragment extends Fragment
     VIEW(LOCATION),
     DONE(VIEW);
     
-    private AddStep(AddStep p)
+    AddStep(AddStep p)
     {
       prev_ = p;
       if(prev_ != null)
@@ -98,7 +98,7 @@ public class PhotoUploadFragment extends Fragment
     private static void save(AddStep a)
     {
       if(Value_ == null)
-        Value_ = new HashMap<AddStep, Integer>();
+        Value_ = new HashMap<>();
       Value_.put(a, Value_.size());
     } // save
 

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsActivity.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsActivity.java
@@ -10,7 +10,6 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceScreen;
 
-import net.cyclestreets.api.POICategories;
 import net.cyclestreets.tiles.TileSource;
 import net.cyclestreets.util.MapPack;
 import net.cyclestreets.util.MessageBox;
@@ -57,8 +56,8 @@ public class SettingsActivity extends PreferenceActivity
   } // setupMapFileList
 
   private void populateMapFileList(final ListPreference mapfilePref) {
-    final List<String> names = new ArrayList<String>();
-    final List<String> files = new ArrayList<String>();
+    final List<String> names = new ArrayList<>();
+    final List<String> files = new ArrayList<>();
 
     for(final MapPack pack : MapPack.availableMapPacks()) {
       names.add(pack.name());

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/Controller.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/Controller.java
@@ -40,7 +40,7 @@ class Controller
     rs_.setListener(listener_);
     rs_.setNotificationActivity((Class<Activity>)context_.getClass());
 
-    if (shouldStart_ == true)
+    if (shouldStart_)
       rs_.startRecording();
   } // onServiceConnected
 

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/DbAdapter.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/DbAdapter.java
@@ -108,7 +108,7 @@ public class DbAdapter {
     final DbAdapter db = new DbAdapter(context.getApplicationContext());
     db.openReadOnly();
 
-    final List<Integer> result = new ArrayList<Integer>();
+    final List<Integer> result = new ArrayList<>();
 
     Cursor c = null;
     try {

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/IRecordService.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/IRecordService.java
@@ -3,11 +3,11 @@ package net.cyclestreets.track;
 import android.app.Activity;
 
 interface IRecordService {
-	public int getState();
+  int getState();
 
-	public TripData startRecording();
-	public TripData stopRecording();
+  TripData startRecording();
+  TripData stopRecording();
 
-	public void setListener(TrackListener ra);
-  public void setNotificationActivity(Class<Activity> activityClass);
+  void setListener(TrackListener ra);
+  void setNotificationActivity(Class<Activity> activityClass);
 }

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/SaveTrip.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/SaveTrip.java
@@ -42,8 +42,8 @@ public class SaveTrip extends Activity
     start(context, unfinishedTrip);
   } // startWithUnsaved
 
-  private final Map<Integer, ToggleButton> purpButtons = new HashMap<Integer,ToggleButton>();
-  private final Map <Integer, String> purpDescriptions = new HashMap<Integer, String>();
+  private final Map<Integer, ToggleButton> purpButtons = new HashMap<>();
+  private final Map <Integer, String> purpDescriptions = new HashMap<>();
   private TripData trip_;
   private String purpose_;
   private Spinner age_;

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripData.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripData.java
@@ -59,7 +59,7 @@ public class TripData {
 
     purp_ = fancystart_ = info_ = "";
 
-    gpspoints = new ArrayList<CyclePoint>();
+    gpspoints = new ArrayList<>();
 
     mDb.open();
     mDb.setStartTime(tripid, startTime_);
@@ -92,7 +92,7 @@ public class TripData {
 
   private void loadJourney() {
     // Otherwise, we need to query DB and build points from scratch.
-    gpspoints = new ArrayList<CyclePoint>();
+    gpspoints = new ArrayList<>();
 
     mDb.openReadOnly();
 

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripDataUploader.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripDataUploader.java
@@ -8,18 +8,12 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.provider.Settings.System;
 
-import net.cyclestreets.api.ApiClient;
 import net.cyclestreets.util.ListFactory;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.text.SimpleDateFormat;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
 
 public class TripDataUploader extends AsyncTask<Void, Void, Boolean> {
   private int NOTIFICATION_ID = 1;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
@@ -33,7 +33,7 @@ public class AccountDetailsActivity extends Activity
     
     EXISTING_SIGNIN_DETAILS(null);
     
-    private RegisterStep(final RegisterStep p)
+    RegisterStep(final RegisterStep p)
     {
       prev_ = p;
       if(prev_ != null)

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
@@ -69,7 +69,7 @@ public class PhotoUploadActivity extends Activity
     VIEW(LOCATION),
     DONE(VIEW);
     
-    private AddStep(AddStep p)
+    AddStep(AddStep p)
     {
       prev_ = p;
       if(prev_ != null)
@@ -96,7 +96,7 @@ public class PhotoUploadActivity extends Activity
     private static void save(AddStep a)
     {
       if(Value_ == null)
-        Value_ = new HashMap<AddStep, Integer>();
+        Value_ = new HashMap<>();
       Value_.put(a, Value_.size());
     } // save
 
@@ -165,7 +165,7 @@ public class PhotoUploadActivity extends Activity
       else
         takePhoto.setEnabled(false);
     }
-    ((Button)photoView_.findViewById(R.id.chooseexisting_button)).setOnClickListener(this);
+    photoView_.findViewById(R.id.chooseexisting_button).setOnClickListener(this);
     {
       final Button textOnly = (Button)photoView_.findViewById(R.id.textonly_button);
       if (allowTextOnly_)

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/Undoable.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/Undoable.java
@@ -2,5 +2,5 @@ package net.cyclestreets;
 
 public interface Undoable
 {
-  public boolean onBackPressed();
+  boolean onBackPressed();
 } // Undoable

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/contacts/Contacts.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/contacts/Contacts.java
@@ -12,7 +12,7 @@ public class Contacts
 {
 	static public List<Contact> load(final Context context) 
 	{
-		final List<Contact> contacts = new ArrayList<Contact>();
+		final List<Contact> contacts = new ArrayList<>();
 		
 		final String[] projection = new String[] {
 				ContactsContract.Data.CONTACT_ID,

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/LocationDatabase.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/LocationDatabase.java
@@ -86,7 +86,7 @@ public class LocationDatabase {
   } // savedLocations
 
   private List<SavedLocation> locations(String where, String[] whereArgs) {
-    final List<SavedLocation> locations = new ArrayList<SavedLocation>();
+    final List<SavedLocation> locations = new ArrayList<>();
     final Cursor cursor = db_.query(DatabaseHelper.LOCATION_TABLE,
         new String[] { BaseColumns._ID, "name", "lat", "lon" },
         where,

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/RouteDatabase.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/RouteDatabase.java
@@ -106,7 +106,7 @@ public class RouteDatabase
   
   public List<RouteSummary> savedRoutes()
   {
-    final List<RouteSummary> routes = new ArrayList<RouteSummary>();
+    final List<RouteSummary> routes = new ArrayList<>();
     final Cursor cursor = db_.query(DatabaseHelper.ROUTE_TABLE,
         new String[] { BaseColumns._ID, "journey", "name", "plan", "distance" },
                         null, 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/MovingState.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/MovingState.java
@@ -2,7 +2,6 @@ package net.cyclestreets.liveride;
 
 import net.cyclestreets.CycleStreetsPreferences;
 import net.cyclestreets.routing.Journey;
-import net.cyclestreets.routing.Segment;
 
 import org.osmdroid.util.GeoPoint;
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/PebbleNotifier.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/PebbleNotifier.java
@@ -33,7 +33,7 @@ public class PebbleNotifier {
   private boolean isSending = false;
 
 
-  private Queue<PebbleDictionary> messageQueue = new LinkedList<PebbleDictionary>();
+  private Queue<PebbleDictionary> messageQueue = new LinkedList<>();
   private BroadcastReceiver pebbleMessageReceiver;
   private BroadcastReceiver pebbleConnectedReceiver;
   private BroadcastReceiver pebbleDisconnectedReceiver;
@@ -67,7 +67,7 @@ public class PebbleNotifier {
 
       @Override
       public void onReceive(Context context, Intent intent) {
-        if (isSending() == false && !messageQueue.isEmpty()) {
+        if (!isSending() && !messageQueue.isEmpty()) {
           setSending(true);
           PebbleDictionary dictionary = messageQueue.peek();
           if (dictionary != null) {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
@@ -17,8 +17,8 @@ import net.cyclestreets.content.RouteSummary;
 public class Route
 {
   public interface Listener {
-    public void onNewJourney(final Journey journey, final Waypoints waypoints);
-    public void onResetJourney();
+    void onNewJourney(final Journey journey, final Waypoints waypoints);
+    void onResetJourney();
   } // Listener
 
   private static class Listeners {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Segments.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Segments.java
@@ -13,7 +13,7 @@ public class Segments implements Iterable<Segment>
   
   public Segments() 
   {
-    segments_ = new ArrayList<Segment>();
+    segments_ = new ArrayList<>();
   } // Segments
   
   public int count() { return segments_.size(); }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Dialog.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Dialog.java
@@ -44,7 +44,7 @@ public class Dialog {
   } // createProgressDialog
   
   public interface UpdatedTextListener {
-    public void updatedText(final String updated);
+    void updatedText(final String updated);
   } // interface UpdatedTextListener
   
   static public void editTextDialog(final Context context, 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/GeoHelper.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/GeoHelper.java
@@ -79,7 +79,7 @@ public class GeoHelper
       ON_TRACK,
       BEFORE_START,
       OFF_END
-    };
+    }
     private final int offset_;
     private Position position_ = Position.ON_TRACK;
     

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/ImageDownloader.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/ImageDownloader.java
@@ -10,17 +10,12 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.os.AsyncTask;
-import android.view.View;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-
-import net.cyclestreets.util.Bitmaps;
 
 public class ImageDownloader {
   static public void get(final String url,

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/MapPack.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/MapPack.java
@@ -26,7 +26,7 @@ public class MapPack
   
   static public List<MapPack> availableMapPacks()
   {
-    final List<MapPack> packs = new ArrayList<MapPack>();
+    final List<MapPack> packs = new ArrayList<>();
     
     final File obbDir = new File(Environment.getExternalStorageDirectory(), "Android/obb");
     if(!obbDir.exists())
@@ -70,9 +70,7 @@ public class MapPack
       final File detailsFile = findMapFile(mapDir, "patch.");
       details.load(new FileInputStream(detailsFile));
     } // try
-    catch(IOException e) { 
-    }
-    catch(RuntimeException e) {
+    catch(IOException | RuntimeException e) {
     } // catch
     return details;
   } // mapName

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/PlaceAutoCompleteTextView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/PlaceAutoCompleteTextView.java
@@ -24,7 +24,7 @@ public class PlaceAutoCompleteTextView extends AutoCompleteTextView
   private GeoLiveAdapter adapter_;
   private GeoPlace place_;
   private Contact contact_;
-  private Set<GeoPlace> localHistory_ = new HashSet<GeoPlace>();
+  private Set<GeoPlace> localHistory_ = new HashSet<>();
   
   public PlaceAutoCompleteTextView(final Context context)
   {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/PlaceViewBase.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/PlaceViewBase.java
@@ -35,7 +35,7 @@ public class PlaceViewBase extends LinearLayout
 {
   public interface OnResolveListener
   {
-    public void onResolve(final GeoPlace place);
+    void onResolve(final GeoPlace place);
   } // interface ResolveListener
 
   ////////////////////////////////
@@ -189,7 +189,7 @@ public class PlaceViewBase extends LinearLayout
   @Override
   public void onClick(final View v)
   {
-    options_ = new ArrayList<String>();
+    options_ = new ArrayList<>();
     for(final GeoPlace gp : allowedPlaces_)
       options_.add(gp.name());
     if (contactsAvailable())

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
@@ -200,22 +200,22 @@ public class ControllerOverlay extends Overlay implements OnDoubleTapListener,
 	//////////////////////////////////////////////////////	
 	private Iterator<TapListener> tapOverlays()
 	{
-		return new OverlayIterator<TapListener>(mapView_, TapListener.class);
+		return new OverlayIterator<>(mapView_, TapListener.class);
 	} // tapOverlays
   private Iterator<ButtonTapListener> buttonTapOverlays()
   {
-    return new OverlayIterator<ButtonTapListener>(mapView_, ButtonTapListener.class);
+    return new OverlayIterator<>(mapView_, ButtonTapListener.class);
   } // buttonTapOverlays
 	private Iterator<MenuListener> menuOverlays()
 	{
-		return new OverlayIterator<MenuListener>(mapView_, MenuListener.class);
+		return new OverlayIterator<>(mapView_, MenuListener.class);
 	} // menuOverlays
 	private Iterator<ContextMenuListener> contextMenuOverlays()
 	{
-		return new OverlayIterator<ContextMenuListener>(mapView_, ContextMenuListener.class);
+		return new OverlayIterator<>(mapView_, ContextMenuListener.class);
 	} // contextMenuOverlays
 	private Iterator<PauseResumeListener> pauseResumeOverlays()
 	{
-	  return new OverlayIterator<PauseResumeListener>(mapView_, PauseResumeListener.class);
+	  return new OverlayIterator<>(mapView_, PauseResumeListener.class);
 	} // pauseResumeOverlays	
 } // class ControllerOverlay

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ItemizedOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ItemizedOverlay.java
@@ -97,7 +97,7 @@ public class ItemizedOverlay<Item extends OverlayItem> extends Overlay
     int markerWidth = (int) (marker.getIntrinsicWidth() * mScale);
     int markerHeight = (int) (marker.getIntrinsicHeight() * mScale);
 
-    rect_.set(0, 0, 0 + markerWidth, 0 + markerHeight);
+    rect_.set(0, 0, markerWidth, markerHeight);
 
     if (hotspot == null)
       hotspot = HotspotPlace.BOTTOM_CENTER;
@@ -190,7 +190,7 @@ public class ItemizedOverlay<Item extends OverlayItem> extends Overlay
     return false;
   } // activateSelectedItems
 
-  private static interface ActiveItem<Item> {
-    public boolean run(final Item aIndex);
+  private interface ActiveItem<Item> {
+    boolean run(final Item aIndex);
   } // interface ActiveItem
 } // class ItemizedOverlay

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
@@ -7,11 +7,11 @@ import org.osmdroid.util.GeoPoint;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Canvas;
-import android.graphics.Matrix;
 import android.location.Location;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
+
 import static net.cyclestreets.util.MenuHelper.createMenuItem;
 import static net.cyclestreets.util.MenuHelper.enableMenuItem;
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/MenuListener.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/MenuListener.java
@@ -5,7 +5,7 @@ import android.view.MenuItem;
 
 public interface MenuListener 
 {
-	public void onCreateOptionsMenu(final Menu menu);
-  public void onPrepareOptionsMenu(final Menu menu);
-	public boolean onMenuItemSelected(final int featureId, final MenuItem item);
+  void onCreateOptionsMenu(final Menu menu);
+  void onPrepareOptionsMenu(final Menu menu);
+  boolean onMenuItemSelected(final int featureId, final MenuItem item);
 } // interface MenuListener

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/MyLocationNewOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/MyLocationNewOverlay.java
@@ -16,7 +16,6 @@ import org.osmdroid.views.overlay.Overlay.Snappable;
 import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
 import org.osmdroid.views.overlay.mylocation.IMyLocationConsumer;
 import org.osmdroid.views.overlay.mylocation.IMyLocationProvider;
-import org.osmdroid.views.util.constants.MapViewConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +63,7 @@ class MyLocationNewOverlay extends Overlay implements IMyLocationConsumer,
   private final IMapController mMapController;
   public IMyLocationProvider mMyLocationProvider;
 
-  private final LinkedList<Runnable> mRunOnFirstFix = new LinkedList<Runnable>();
+  private final LinkedList<Runnable> mRunOnFirstFix = new LinkedList<>();
   private final Point mMapCoords = new Point();
 
   private Location mLocation;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/OverlayHelper.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/OverlayHelper.java
@@ -44,5 +44,5 @@ public class OverlayHelper
   
   private CycleMapView view_;
   @SuppressWarnings("rawtypes")
-  private Map<Class, Overlay> memo_ = new HashMap<Class, Overlay>();
+  private Map<Class, Overlay> memo_ = new HashMap<>();
 } // OverlayHelper

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/POIOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/POIOverlay.java
@@ -373,7 +373,7 @@ public class POIOverlay
     if(item.getItemId() != R.string.ic_menu_poi)
       return false;
 
-    if(chooserShowing_ == true)
+    if(chooserShowing_)
       return true;
 
     chooserShowing_  = true;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/PauseResumeListener.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/PauseResumeListener.java
@@ -3,6 +3,6 @@ package net.cyclestreets.views.overlay;
 import android.content.SharedPreferences;
 
 public interface PauseResumeListener {
-  public void onResume(SharedPreferences prefs);
-  public void onPause(SharedPreferences.Editor prefs);
+  void onResume(SharedPreferences prefs);
+  void onPause(SharedPreferences.Editor prefs);
 } // interface PauseResumeListener

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/PhotoUploadButtonOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/PhotoUploadButtonOverlay.java
@@ -1,7 +1,6 @@
 package net.cyclestreets.views.overlay;
 
 import org.osmdroid.views.MapView;
-import org.osmdroid.views.overlay.Overlay;
 
 import android.content.Context;
 import android.content.Intent;
@@ -11,7 +10,6 @@ import android.view.MotionEvent;
 
 import net.cyclestreets.PhotoUploadActivity;
 import net.cyclestreets.view.R;
-import net.cyclestreets.views.CycleMapView;
 
 public class PhotoUploadButtonOverlay extends ButtonOnlyOverlay {
   /////////////////////////////////////////////////////

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
@@ -135,7 +135,7 @@ public class TapToRouteOverlay extends Overlay
     highlightBrush_ = Brush.HighlightBrush(context_);
     lowlightBrush_ = Brush.LowlightBrush(context_);
 
-    waymarkers_ = new ArrayList<OverlayItem>();
+    waymarkers_ = new ArrayList<>();
 
     tapState_ = TapToRoute.start();
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ThereOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ThereOverlay.java
@@ -19,7 +19,7 @@ import android.view.MotionEvent;
 public class ThereOverlay extends Overlay
                           implements TapListener
 {
-  static public interface LocationListener {
+  public interface LocationListener {
     void onSetLocation(final IGeoPoint point);
   }
 

--- a/libraries/cyclestreets-view/src/main/java/org/mapsforge/android/maps/MapsforgeOSMDroidTileProvider.java
+++ b/libraries/cyclestreets-view/src/main/java/org/mapsforge/android/maps/MapsforgeOSMDroidTileProvider.java
@@ -14,7 +14,6 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.osmdroid.http.HttpClientFactory;
 import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileRequestState;
@@ -129,9 +128,7 @@ public class MapsforgeOSMDroidTileProvider extends MapTileModuleProviderBase
 
         final Drawable result = fallbackTileSource_.getDrawable(new ByteArrayInputStream(data));
         return result;
-      } catch (final UnknownHostException e) {
-        throw new CantContinueException(e);
-      } catch (final LowMemoryException e) {
+      } catch (final UnknownHostException | LowMemoryException e) {
         throw new CantContinueException(e);
       } catch (final Exception e) {
         return null;


### PR DESCRIPTION
I thought that before working on a more significant PR I'd get myself into the swing of things by fixing some low-hanging fruit.  This PR does the following:
-  Remove redundant modifier `static` on inner interfaces
-  Remove redundant modifier `public` for interface methods
-  Remove unnecessary `final` declaration on `static` and/or `private` methods
-  Remove redundant `private` modifier for enum constructors
-  Remove pointless boolean expressions
-  Remove unused imports
-  Collapse identical `catch` blocks
-  Use diamond operator
-  Remove redundant type cast