### PR TITLE
Upgrade minor/patch versions of dependencies

### DIFF
--- a/cyclestreets.vNext/build.gradle
+++ b/cyclestreets.vNext/build.gradle
@@ -1,8 +1,8 @@
 evaluationDependsOn(':libraries:cyclestreets-fragments')
 
 dependencies {
-  compile project(':libraries:cyclestreets-fragments'),
-          'ch.acra:acra:4.8.5'
+  compile project(':libraries:cyclestreets-fragments')
+  compile 'ch.acra:acra:4.8.5'
 }
 
 android {

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -1,13 +1,11 @@
-
-
 configurations {
   compile.exclude module: 'commons-logging'
+  compile.exclude module: 'httpclient'
 }
 
 dependencies {
-  compile 'org.osmdroid:osmdroid-android:4.3',
-      'org.apache.james:apache-mime4j:0.6',
-      'org.apache.httpcomponents:httpmime:4.1',
-      'org.slf4j:slf4j-android:1.6.1-RC1'
+  compile 'org.osmdroid:osmdroid-android:4.3'
+  compile 'org.apache.james:apache-mime4j:0.7.2'
+  compile 'org.apache.httpcomponents:httpmime:4.5.2'
+  compile 'org.slf4j:slf4j-android:1.7.21'
 }
-

--- a/libraries/cyclestreets-fragments/build.gradle
+++ b/libraries/cyclestreets-fragments/build.gradle
@@ -1,6 +1,6 @@
 evaluationDependsOn(':libraries:cyclestreets-view')
 
 dependencies {
-  compile project(':libraries:cyclestreets-view'),
-          'com.jjoe64:graphview:3.1.3'
+  compile project(':libraries:cyclestreets-view')
+  compile 'com.jjoe64:graphview:3.1.4'
 }

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -1,9 +1,8 @@
 evaluationDependsOn(':libraries:cyclestreets-core')
 
 dependencies {
-  compile project(':libraries:cyclestreets-core'),
-      files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar'),
-      'com.android.support:appcompat-v7:20.+',
-      'com.getpebble:pebblekit:3.0.0@aar'
+  compile project(':libraries:cyclestreets-core')
+  compile files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
+  compile 'com.android.support:appcompat-v7:20.+'
+  compile 'com.getpebble:pebblekit:3.1.0@aar'
 }
-


### PR DESCRIPTION
-  Upgrade minor/patch versions of dependencies
-  While we're at it, fix alignment and conform with convention (as I understand it!) for Gradle dependency definition layout.

Note that `org.osmdroid:osmdroid-android:4.3' has a major upgrade available of `5.2`.  I haven't changed that in this PR as there are associated API changes.