### PR TITLE
Migrate remaining usages of Apache HttpClient

### DIFF
--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -5,8 +5,6 @@ configurations {
 
 dependencies {
   compile 'org.osmdroid:osmdroid-android:4.3'
-  compile 'org.apache.james:apache-mime4j:0.7.2'
-  compile 'org.apache.httpcomponents:httpmime:4.5.2'
   compile 'org.slf4j:slf4j-android:1.7.21'
 
   // Retrofit for HTTP Client activities

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
@@ -4,20 +4,14 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.preference.ListPreference;
 
-import net.cyclestreets.AppInfo;
 import net.cyclestreets.CycleStreetsPreferences;
 import net.cyclestreets.util.MapPack;
 import net.cyclestreets.util.MessageBox;
 import net.cyclestreets.util.Screen;
 import net.cyclestreets.view.R;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.CoreProtocolPNames;
 import org.mapsforge.android.maps.MapsforgeOSMTileSource;
 import org.osmdroid.ResourceProxy;
-import org.osmdroid.http.HttpClientFactory;
-import org.osmdroid.http.IHttpClientFactory;
 import org.osmdroid.tileprovider.MapTileProviderBase;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.XYTileSource;
@@ -209,17 +203,6 @@ public class TileSource {
 
   public static MapTileProviderBase mapTileProvider(final Context context) {
     addBuiltInSources(context);
-
-    final IHttpClientFactory httpFactory = new IHttpClientFactory() {
-      @Override
-      public HttpClient createHttpClient() {
-        final DefaultHttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.USER_AGENT, AppInfo.version(context));
-        return client;
-      }
-    };
-    HttpClientFactory.setFactoryInstance(httpFactory);
-
     return new CycleMapTileProvider(context, TileSource.source(TileSource.DEFAULT_RENDERER).renderer());
   } // MapTileProviderBase
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/UserAgentInterceptor.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/UserAgentInterceptor.java
@@ -1,0 +1,25 @@
+package net.cyclestreets.tiles;
+
+import java.io.IOException;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class UserAgentInterceptor implements Interceptor {
+
+  private final String userAgent;
+
+  public UserAgentInterceptor(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+    HttpUrl newUrl = request.url().newBuilder().addQueryParameter("CoreProtocolPNames.USER_AGENT", userAgent).build();
+    Request newRequest = request.newBuilder().url(newUrl).build();
+    return chain.proceed(newRequest);
+  }
+}


### PR DESCRIPTION
As discussed previously, before we can migrate to the latest osmdroid library, and generally for getting our app up-to-date, we need to remove the remaining usages of `org.apache.http.*` classes.  These existed in the following places:

1.  `TileSource` - to initialise the `HttpClientFactory` to set the `http.useragent` to be `AppInfo.version()`
2.  `ImageDownloader` - for downloading CycleStreets images, using the `thumbnailUrl` field returned from the `photomap.locations` API.
3.  `CycleStreetsTileDownloader` and `MapsforgeOSMDroidTileProvider` - for getting map tiles (I haven't worked out what the differences between these are; my guess is one would use the downloadable map pack, but @mvl22 @jezhiggins I'd welcome some more background info on this).

My thought processes went like this:
-  Using Retrofit requires you to set a `baseUrl` when initialising the client object.
-  For `ImageDownloader` we could hardcode this to be `https://www.cyclestreets.net/` (as all the paths *currently* start with `https://www.cyclestreets.net/location/`) but that feels to me a bit hacky.
-  In any case, we couldn't do that for the OSM case because those produce dynamic baseUrls (see https://github.com/osmdroid/osmdroid/blob/master/osmdroid-android/src/main/java/org/osmdroid/tileprovider/tilesource/OnlineTileSourceBase.java#L29-34).
-  To solve this, we therefore have two options.
  * Create Retrofit client objects on the fly.
  * Use OkHttp directly.

Since at the moment we're not doing anything with async on these requests, and because we have no prior knowledge of API structure, just a URL string that we're given, I see no advantage in the more heavyweight Retrofit wrapper for these cases and have therefore used OkHttp directly.