### PR TITLE
Fix three silly bugs

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 public class ApiClient
 {
-  private final static String API_HOST = "www.cyclestreets.net";
-  private final static String API_HOST_V2 = "api.cyclestreets.net";
+  private final static String API_HOST = "https://www.cyclestreets.net";
+  private final static String API_HOST_V2 = "https://api.cyclestreets.net";
 
   private static ApiCustomiser customiser;
   private static Context context;
@@ -28,14 +28,16 @@ public class ApiClient
 
   public static void initialise(final Context context) {
     ApiClient.context = context;
-    POICategories.backgroundLoad();
-    PhotomapCategories.backgroundLoad();
 
     retrofitApiClient = new RetrofitApiClient.Builder()
-        .withApiKey(findApiKey(ApiClient.context))
+        .withContext(context())
+        .withApiKey(findApiKey(context()))
         .withV1Host(API_HOST)
         .withV2Host(API_HOST_V2)
         .build();
+
+    POICategories.backgroundLoad();
+    PhotomapCategories.backgroundLoad();
   }
 
   public static void setCustomiser(ApiCustomiser customiser) {


### PR DESCRIPTION
The following three bugs have been fixed.  They're all rather silly.
-  Hostnames passed to Retrofit need the scheme to be included.
-  Retrofit needs the context to determine its cache dir.
-  Don't attempt to use Retrofit before it's been initialised.

Now that these changes have been made, the app starts up once again when I tested it locally.

Apologies for breaking the builds; I'll endeavour to make sure it doesn't happen again!