### PR TITLE
Add basic app startup tests using Espresso

### DIFF
--- a/cyclestreets.vNext/build.gradle
+++ b/cyclestreets.vNext/build.gradle
@@ -3,10 +3,16 @@ evaluationDependsOn(':libraries:cyclestreets-fragments')
 dependencies {
   compile project(':libraries:cyclestreets-fragments')
   compile 'ch.acra:acra:4.9.0'
+
+  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+  androidTestCompile 'com.android.support.test:runner:0.5'
+  androidTestCompile 'com.android.support:support-annotations:23.4.0'
 }
 
 android {
   defaultConfig {
     applicationId 'net.cyclestreets'
+
+    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
   }
 }

--- a/cyclestreets.vNext/src/androidTest/java/net/cyclestreets/AppStartupTest.java
+++ b/cyclestreets.vNext/src/androidTest/java/net/cyclestreets/AppStartupTest.java
@@ -1,0 +1,22 @@
+package net.cyclestreets;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class AppStartupTest {
+
+  @Rule
+  public ActivityTestRule<CycleStreets> mActivityRule = new ActivityTestRule<>(CycleStreets.class);
+
+  @Test
+  public void testAppStartup() {
+    System.out.println("I've started up without crashing.");
+  }
+}

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -19,7 +19,13 @@ dependencies {
   compile 'com.squareup.retrofit2:converter-jackson:2.1.0'
   compile 'de.grundid.opendatalab:geojson-jackson:1.6'
 
-  testCompile 'com.github.tomakehurst:wiremock-standalone:2.1.0-beta'
+  // Jackson is already included transitively from multiple sources; we specify explicit versions
+  // to ensure consistency across these artifacts.
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.7'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.7.7'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.7.7'
+
+  testCompile 'com.github.tomakehurst:wiremock-standalone:2.1.12'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'org.mockito:mockito-core:1.10.19'

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -5,4 +5,8 @@ dependencies {
   compile files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
   compile 'com.android.support:appcompat-v7:20.+'
   compile 'com.getpebble:pebblekit:3.1.0@aar'
+
+  // In the main app project, we're already pulling in 23.x via the `acra` dependency.
+  compile 'com.android.support:support-v4:23.4.0'
+  compile 'com.android.support:support-annotations:23.4.0'
 }


### PR DESCRIPTION
See https://google.github.io/android-testing-support-library/docs/espresso/index.html for details of Espresso.  It's the framework that was generally recommended by the helpful folks in the Android development community of practice where I work.

With these changes, **and either an emulator running or a real Android device connected**, you can run `./gradlew cyclestreets.vNext:connectedCheck`.  I have proved that this a valid test for app startup, since we know `master` is currently broken, and the test fails with just the changes in this PR, but passes once the bug fixes in #147 are merged in.

I propose getting this PR (and for that matter #147!) in as-is.  Subsequently we can look at automating the creation, starting and stopping of an emulator on CI and/or local builds, so that this functional test (and others which will follow) can then become part of the build process.