### PR TITLE
Include build identifier in version on About page

### DIFF
--- a/cyclestreets.vNext/src/main/assets/credits.html
+++ b/cyclestreets.vNext/src/main/assets/credits.html
@@ -51,7 +51,7 @@
   <hr/>
     <h3>Android App</h3>
     <p>
-  Android App written by Jez Higgins with contributions by Christopher Fraser, Jonathan
+  Android App written by Jez Higgins with contributions by Oliver Lockwood, Christopher Fraser, Jonathan
   Gray, Theodore Hong, Farid Kurbanov, kyegupov, Shaun McDonald, Simon Nuttall, John Singleton, Colin Watson.
     </p>
     <p>

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -32,3 +32,13 @@ dependencies {
   testCompile 'org.robolectric:robolectric:3.0'
   testCompile 'commons-io:commons-io:2.4'
 }
+
+def buildNumber = {
+  System.getenv("BUILD_IDENTIFIER") ?: "local-build"
+}()
+
+android {
+  defaultConfig {
+    buildConfigField 'String', 'BUILD_IDENTIFIER', "\"${buildNumber}\""
+  }
+}

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/AppInfo.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/AppInfo.java
@@ -4,25 +4,28 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
+import net.cyclestreets.core.BuildConfig;
+
 public class AppInfo {
   private static String version_ = null;
 
   public static String version(final Context context) {
     if (version_ == null)
-      version_ = String.format("%s/%s", context.getPackageName(), versionName(context));
+      version_ = String.format("%s/%s/%s", context.getPackageName(),
+                               versionName(context), BuildConfig.BUILD_IDENTIFIER);
     return version_;
-  } // version
+  }
 
   private static String versionName(final Context context) {
     try {
       final PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
       return info.versionName;
-    } // try
+    }
     catch (PackageManager.NameNotFoundException nnfe) {
       // like this is going to happen
       return UNKNOWN;
-    } // catch
-  } // versionName
+    }
+  }
 
   private static final String UNKNOWN = "unknown";
-} // versionName}
+}


### PR DESCRIPTION
In conjunction with changes I intend to make to our Jenkins build, this addresses #159.

Local builds, created on a developer machine, will appear along the lines of `net.cyclestreets/3.4/local-build`:
<img width="304" alt="screen shot 2016-10-11 at 16 01 15" src="https://cloud.githubusercontent.com/assets/6017680/19275528/fb622bec-8fcb-11e6-87ce-0b1a7256aed5.png">


Proper CI builds will appear along the lines of `net.cyclestreets/3.4/2016-10-11-0045`.
