### PR TITLE
Fix hardcoded text to support internationalisation

### DIFF
--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/PhotoUploadFragment.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/PhotoUploadFragment.java
@@ -323,15 +323,15 @@ public class PhotoUploadFragment extends Fragment
   @Override
   public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) 
   {
-    createMenuItem(menu, R.string.ic_menu_restart, Menu.NONE, R.drawable.ic_menu_rotate);
-    createMenuItem(menu, R.string.ic_menu_back, Menu.NONE, R.drawable.ic_menu_revert);
+    createMenuItem(menu, R.string.all_menu_restart, Menu.NONE, R.drawable.ic_menu_rotate);
+    createMenuItem(menu, R.string.all_menu_back, Menu.NONE, R.drawable.ic_menu_revert);
   } // onCreateOptionsMenu
   
   @Override
   public void onPrepareOptionsMenu(final Menu menu)
   {
-    enableMenuItem(menu, R.string.ic_menu_restart, step_ != AddStep.PHOTO);
-    enableMenuItem(menu, R.string.ic_menu_back, step_ != AddStep.PHOTO && step_ != AddStep.VIEW);
+    enableMenuItem(menu, R.string.all_menu_restart, step_ != AddStep.PHOTO);
+    enableMenuItem(menu, R.string.all_menu_back, step_ != AddStep.PHOTO && step_ != AddStep.VIEW);
   } // onPrepareOptionsMenu
     
   @Override
@@ -339,13 +339,13 @@ public class PhotoUploadFragment extends Fragment
   {
     final int menuItem = item.getItemId();
 
-    if(R.string.ic_menu_restart == menuItem) {
+    if(R.string.all_menu_restart == menuItem) {
       step_ = AddStep.PHOTO;
       setupView();
       return true;
     }
 
-    if(R.string.ic_menu_back == menuItem) {
+    if(R.string.all_menu_back == menuItem) {
       onBackPressed();
       return true;
     }
@@ -800,7 +800,7 @@ if (url.startsWith("content://com.google.android.apps.photos.content")){
       dateTime_ = dateTime;
       caption_ = caption;
       
-      progress_ = Dialog.createProgressDialog(context, R.string.uploading_photo);
+      progress_ = Dialog.createProgressDialog(context, R.string.photo_uploading);
     } // UploadPhotoTask
     
     @Override

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsActivity.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsActivity.java
@@ -114,7 +114,7 @@ public class SettingsActivity extends PreferenceActivity
     if(mapfilePref.getEntryValues().length == 0) {
       mapfilePref.setEnabled(false);
       MessageBox.YesNo(getListView(),
-                       R.string.no_map_packs,
+                       R.string.settings_no_map_packs,
                        new DialogInterface.OnClickListener() {
                          public void onClick(DialogInterface arg0, int arg1) {
                            MapPack.searchGooglePlay(SettingsActivity.this);

--- a/libraries/cyclestreets-track/src/main/res/layout/completed_journey.xml
+++ b/libraries/cyclestreets-track/src/main/res/layout/completed_journey.xml
@@ -4,22 +4,34 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
   <RelativeLayout android:id="@+id/RelativeLayout01"
-                  android:layout_width="wrap_content" android:layout_height="wrap_content"
-                  android:paddingLeft="4sp" android:paddingTop="4sp"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:paddingLeft="4sp"
+                  android:paddingTop="4sp"
                   android:paddingRight="6sp">
     <TextView android:id="@+id/journey_purpose"
-              android:layout_height="wrap_content" android:layout_width="wrap_content"
-              android:layout_alignParentLeft="true" android:layout_marginLeft="2sp"
-              android:textSize="20sp" android:textStyle="bold" android:text="purpose of trip"></TextView>
+              android:layout_height="wrap_content"
+              android:layout_width="wrap_content"
+              android:layout_alignParentLeft="true"
+              android:layout_marginLeft="2sp"
+              android:textSize="20sp"
+              android:textStyle="bold"
+              android:text="@string/completedjourney_purpose"/>
     <TextView android:id="@+id/journey_start"
-              android:layout_width="wrap_content" android:layout_height="wrap_content"
-              android:layout_alignParentRight="true" android:textSize="20sp"
-              android:textStyle="bold" android:text="start time"></TextView>
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_alignParentRight="true"
+              android:textSize="20sp"
+              android:textStyle="bold"
+              android:text="@string/completedjourney_start_time"/>
   </RelativeLayout>
-  <TextView android:layout_height="wrap_content" android:id="@+id/journey_info"
-            android:layout_width="match_parent" android:layout_marginLeft="7sp"
-            android:paddingBottom="8sp" android:text="journey info"
-            android:layout_marginRight="7sp"></TextView>
+  <TextView android:layout_height="wrap_content"
+            android:id="@+id/journey_info"
+            android:layout_width="match_parent"
+            android:layout_marginLeft="7sp"
+            android:paddingBottom="8sp"
+            android:text="@string/completedjourney_info"
+            android:layout_marginRight="7sp"/>
   <RelativeLayout
     android:id="@+id/mapholder"
     android:layout_width="fill_parent"

--- a/libraries/cyclestreets-track/src/main/res/layout/journey_in_progress.xml
+++ b/libraries/cyclestreets-track/src/main/res/layout/journey_in_progress.xml
@@ -11,14 +11,14 @@
               android:textStyle="bold"
               android:layout_marginTop="5sp"
               android:textSize="26sp"
-              android:text="Distance:" ></TextView>
+              android:text="@string/journey_distance"/>
     <TextView android:id="@+id/journey_distance"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_alignParentRight="true"
               android:textStyle="bold"
               android:layout_marginTop="5sp"
-              android:layout_marginRight="5sp" android:textSize="26sp"></TextView>
+              android:layout_marginRight="5sp" android:textSize="26sp"/>
   </RelativeLayout>
   <RelativeLayout android:layout_height="wrap_content" android:layout_width="match_parent" android:layout_marginTop="5sp">
     <TextView android:layout_width="wrap_content"
@@ -27,14 +27,14 @@
               android:textStyle="bold"
               android:layout_marginTop="5sp"
               android:textSize="26sp"
-              android:text="Journey Time:" ></TextView>
+              android:text="@string/journey_time"/>
     <TextView android:id="@+id/journey_time"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_alignParentRight="true"
               android:textStyle="bold"
               android:layout_marginTop="5sp"
-              android:layout_marginRight="5sp" android:textSize="26sp"></TextView>
+              android:layout_marginRight="5sp" android:textSize="26sp"/>
   </RelativeLayout>
   <RelativeLayout android:layout_height="wrap_content" android:layout_width="match_parent" android:layout_marginTop="5sp">
     <TextView android:layout_width="wrap_content"
@@ -43,14 +43,15 @@
               android:textStyle="bold"
               android:layout_marginTop="5sp"
               android:textSize="26sp"
-              android:text="Current Speed:" ></TextView>
+              android:text="@string/journey_current_speed"/>
     <TextView android:id="@+id/journey_speed"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_alignParentRight="true"
               android:textStyle="bold"
               android:layout_marginTop="5sp"
-              android:layout_marginRight="5sp" android:textSize="26sp"></TextView>
+              android:layout_marginRight="5sp"
+              android:textSize="26sp"/>
   </RelativeLayout>
 
   <RelativeLayout
@@ -66,9 +67,10 @@
       android:text=""/>
   </RelativeLayout>
   <Button android:id="@+id/ButtonFinished"
-          android:text="@string/finishedButtonLabel"
+          android:text="@string/journey_finish_button"
           android:layout_height="wrap_content"
           android:layout_width="match_parent"
           android:drawableLeft="@android:drawable/ic_media_next"
-          android:textStyle="bold" android:textSize="18sp"></Button>
+          android:textStyle="bold"
+          android:textSize="18sp"/>
 </LinearLayout>

--- a/libraries/cyclestreets-track/src/main/res/layout/save.xml
+++ b/libraries/cyclestreets-track/src/main/res/layout/save.xml
@@ -1,159 +1,211 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/ScrollView01" android:layout_width="wrap_content"
-	android:layout_height="wrap_content">
+            android:id="@+id/ScrollView01" android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
   <RelativeLayout android:layout_width="fill_parent"
-		  android:layout_height="fill_parent">
+                  android:layout_height="fill_parent">
+
     <LinearLayout android:id="@+id/LinearLayout02" android:orientation="vertical"
-		  android:layout_width="fill_parent" android:layout_height="wrap_content">
-      <TextView android:id="@+id/TextView01" android:layout_width="wrap_content"
-		android:layout_height="wrap_content" android:textSize="16sp"
-		android:paddingTop="8sp" android:layout_marginLeft="5sp"
-		android:text="Finished recording.  Choose a trip purpose:"
-		android:paddingBottom="4sp"></TextView>
+                  android:layout_width="fill_parent" android:layout_height="wrap_content">
+      <TextView android:id="@+id/TextView01"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:paddingTop="8sp"
+                android:layout_marginLeft="5sp"
+                android:text="@string/save_choose_purpose_hint"
+                android:paddingBottom="4sp"/>
       <LinearLayout android:id="@+id/LinearLayout03"
-		    android:layout_height="wrap_content" android:orientation="horizontal"
-		    android:layout_width="fill_parent"></LinearLayout>
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_width="fill_parent"/>
       <TableLayout android:id="@+id/TableLayout01"
-		   android:layout_height="wrap_content" android:layout_width="fill_parent">
-	<TableRow android:id="@+id/TableRow01"
-		  android:layout_height="wrap_content" android:layout_width="fill_parent"
-		  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
-	  <ToggleButton android:layout_height="wrap_content"
-			android:textOff="Commute" android:textOn="Commute"
-			android:layout_width="wrap_content" android:layout_weight="1"
-			android:id="@+id/ToggleCommute" android:textSize="11sp"
-			android:drawableTop="@drawable/commute"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:textOff="School" android:textOn="School" android:textSize="11sp"
-			android:id="@+id/ToggleSchool" android:drawableTop="@drawable/school"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="fill_parent" android:id="@+id/ToggleWorkRel"
-			android:textSize="9sp" android:drawableTop="@drawable/workrel"
-			android:layout_weight="0.7" android:textOff="Work-Related"
-			android:textOn="Work-Related"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:textOff="Exercise" android:textOn="Exercise"
-			android:textSize="11sp" android:id="@+id/ToggleExercise"
-			android:drawableTop="@drawable/exercise"></ToggleButton>
+                   android:layout_height="wrap_content"
+                   android:layout_width="fill_parent">
 
+        <TableRow android:id="@+id/TableRow01"
+                  android:layout_height="wrap_content" android:layout_width="fill_parent"
+                  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
+          <ToggleButton android:layout_height="wrap_content"
+                        android:textOff="@string/save_purpose_commute"
+                        android:textOn="@string/save_purpose_commute"
+                        android:layout_width="wrap_content"
+                        android:layout_weight="1"
+                        android:id="@+id/ToggleCommute"
+                        android:textSize="11sp"
+                        android:drawableTop="@drawable/commute"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textOff="@string/save_purpose_school"
+                        android:textOn="@string/save_purpose_school"
+                        android:textSize="11sp"
+                        android:id="@+id/ToggleSchool"
+                        android:drawableTop="@drawable/school"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="fill_parent"
+                        android:id="@+id/ToggleWorkRel"
+                        android:textSize="9sp"
+                        android:drawableTop="@drawable/workrel"
+                        android:layout_weight="0.7"
+                        android:textOff="@string/save_purpose_work"
+                        android:textOn="@string/save_purpose_work"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textOff="@string/save_purpose_exercise"
+                        android:textOn="@string/save_purpose_exercise"
+                        android:textSize="11sp"
+                        android:id="@+id/ToggleExercise"
+                        android:drawableTop="@drawable/exercise"/>
+        </TableRow>
 
-	</TableRow>
-	<TableRow android:id="@+id/TableRow02"
-		  android:layout_height="wrap_content" android:layout_width="fill_parent"
-		  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
-	  <ToggleButton android:layout_height="wrap_content"
-			android:layout_width="wrap_content" android:layout_weight="1"
-			android:textSize="11sp" android:textOff="Social" android:textOn="Social"
-			android:id="@+id/ToggleSocial" android:drawableTop="@drawable/social"
-			android:nextFocusUp="@+id/ToggleCommute" android:nextFocusDown="@+id/NotesField"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:textSize="11sp" android:textOff="Shopping" android:textOn="Shopping"
-			android:id="@+id/ToggleShopping" android:drawableTop="@drawable/shopping"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="fill_parent" android:textOff="Errand"
-			android:textOn="Errand" android:id="@+id/ToggleErrand"
-			android:textSize="11sp" android:drawableTop="@drawable/errands"
-			android:layout_weight="0.7"></ToggleButton>
-	  <ToggleButton android:layout_width="wrap_content"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:textSize="11sp" android:textOff="Other" android:textOn="Other"
-			android:id="@+id/ToggleOther" android:drawableTop="@drawable/other"></ToggleButton>
-	</TableRow>
+        <TableRow android:id="@+id/TableRow02"
+                  android:layout_height="wrap_content" android:layout_width="fill_parent"
+                  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
+          <ToggleButton android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:layout_weight="1"
+                        android:textSize="11sp"
+                        android:textOff="@string/save_purpose_social"
+                        android:textOn="@string/save_purpose_social"
+                        android:id="@+id/ToggleSocial"
+                        android:drawableTop="@drawable/social"
+                        android:nextFocusUp="@+id/ToggleCommute"
+                        android:nextFocusDown="@+id/NotesField"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textSize="11sp"
+                        android:textOff="@string/save_purpose_shopping"
+                        android:textOn="@string/save_purpose_shopping"
+                        android:id="@+id/ToggleShopping"
+                        android:drawableTop="@drawable/shopping"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="fill_parent"
+                        android:textOff="@string/save_purpose_errand"
+                        android:textOn="@string/save_purpose_errand"
+                        android:id="@+id/ToggleErrand"
+                        android:textSize="11sp"
+                        android:drawableTop="@drawable/errands"
+                        android:layout_weight="0.7"/>
+          <ToggleButton android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textSize="11sp"
+                        android:textOff="@string/save_purpose_other"
+                        android:textOn="@string/save_purpose_other"
+                        android:id="@+id/ToggleOther"
+                        android:drawableTop="@drawable/other"/>
+        </TableRow>
+
       </TableLayout>
+
       <TextView android:layout_width="wrap_content"
-		android:layout_height="wrap_content" android:layout_marginLeft="5sp"
-		android:paddingBottom="2sp" android:paddingTop="4sp"
-		android:id="@+id/TextPurpDescription" android:text="     "
-		android:lines="3" android:bufferType="spannable" android:textSize="14sp"></TextView>
-  <EditText android:bufferType="editable"
-		android:cursorVisible="true" android:layout_width="fill_parent"
-		android:selectAllOnFocus="true" android:layout_height="fill_parent"
-		android:id="@+id/NotesField" android:layout_marginTop="10sp"
-		android:inputType="text" android:hint="Comments about your trip"
-		android:layout_marginRight="2sp" android:layout_marginLeft="2sp"
-    android:maxLength="255"
-		android:nextFocusDown="@+id/ButtonSubmit" android:nextFocusRight="@+id/ButtonSubmit"
-		android:nextFocusUp="@+id/ToggleSocial" android:imeOptions="actionDone"></EditText>
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="5sp"
+                android:paddingBottom="2sp"
+                android:paddingTop="4sp"
+                android:id="@+id/TextPurpDescription"
+                android:text="@string/save_wide_blank"
+                android:lines="3"
+                android:bufferType="spannable"
+                android:textSize="14sp"/>
+      <EditText android:bufferType="editable"
+                android:cursorVisible="true"
+                android:layout_width="fill_parent"
+                android:selectAllOnFocus="true"
+                android:layout_height="fill_parent"
+                android:id="@+id/NotesField"
+                android:layout_marginTop="10sp"
+                android:inputType="text"
+                android:hint="@string/save_trip_comments_hint"
+                android:layout_marginRight="2sp"
+                android:layout_marginLeft="2sp"
+                android:maxLength="255"
+                android:nextFocusDown="@+id/ButtonSubmit"
+                android:nextFocusRight="@+id/ButtonSubmit"
+                android:nextFocusUp="@+id/ToggleSocial"
+                android:imeOptions="actionDone"/>
 
-
-    <TableLayout android:layout_height="wrap_content" android:layout_width="fill_parent">
-      <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
-                android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
-        <TextView
-          android:layout_width="wrap_content"
-          android:layout_height="match_parent"
-          android:gravity="center"
-          android:textSize="16sp"
-          android:text="Age:"/>
-        <Spinner
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          android:layout_weight="1"
-          android:id="@+id/age"/>
-      </TableRow>
-      <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
-                android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
-        <TextView
-          android:layout_width="wrap_content"
-          android:layout_height="match_parent"
-          android:gravity="center"
-          android:textSize="16sp"
-          android:text="Gender:"/>
-        <Spinner
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          android:layout_weight="1"
-          android:id="@+id/gender"/>
-      </TableRow>
-      <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
-                android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
-        <LinearLayout android:layout_width="wrap_content"
-                      android:layout_height="match_parent"
-                      android:orientation="vertical"
-                      android:gravity="center">
+      <TableLayout android:layout_height="wrap_content" android:layout_width="fill_parent">
+        <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
+                  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
           <TextView
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:gravity="center"
-            android:textSize="14sp"
-            android:text="Level of"/>
+            android:textSize="16sp"
+            android:text="@string/save_age"/>
+          <Spinner
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:id="@+id/age"/>
+        </TableRow>
+        <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
+                  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
           <TextView
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:gravity="center"
-            android:textSize="14sp"
-            android:text="cycling"/>
-          <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textSize="14sp"
-            android:text="experience:"/>
-        </LinearLayout>
-        <Spinner
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          android:layout_weight="1"
-          android:id="@+id/experience"/>
-      </TableRow>
-    </TableLayout>
+            android:textSize="16sp"
+            android:text="@string/save_gender"/>
+          <Spinner
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:id="@+id/gender"/>
+        </TableRow>
+        <TableRow android:layout_height="wrap_content" android:layout_width="fill_parent"
+                  android:layout_marginLeft="2sp" android:layout_marginRight="4sp">
+          <LinearLayout android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical"
+                        android:gravity="center">
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:gravity="center"
+                      android:textSize="14sp"
+                      android:text="@string/save_level_of"/>
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:gravity="center"
+                      android:textSize="14sp"
+                      android:text="@string/save_cycling"/>
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:gravity="center"
+                      android:textSize="14sp"
+                      android:text="@string/save_experience"/>
+          </LinearLayout>
+          <Spinner android:layout_width="match_parent"
+                   android:layout_height="match_parent"
+                   android:layout_weight="1"
+                   android:id="@+id/experience"/>
+        </TableRow>
+      </TableLayout>
 
       <LinearLayout android:id="@+id/LinearLayout01"
-		    android:layout_height="wrap_content" android:layout_width="fill_parent"
-		    android:paddingTop="10sp">
-	<Button android:layout_height="wrap_content" android:text="Discard"
-		android:layout_width="fill_parent" android:layout_weight="1"
-		android:drawableLeft="@android:drawable/ic_menu_close_clear_cancel"
-		android:id="@+id/ButtonDiscard" android:textStyle="bold"
-		android:textSize="18sp"></Button>
-	<Button android:layout_height="wrap_content" android:text="Submit"
-		android:layout_width="fill_parent" android:layout_weight="1"
-		android:drawableLeft="@android:drawable/ic_menu_save" android:id="@+id/ButtonSubmit"
-		android:textStyle="bold" android:textSize="18sp"></Button>
+                    android:layout_height="wrap_content"
+                    android:layout_width="fill_parent"
+                    android:paddingTop="10sp">
+        <Button android:layout_height="wrap_content"
+                android:layout_width="fill_parent"
+                android:layout_weight="1"
+                android:drawableLeft="@android:drawable/ic_menu_close_clear_cancel"
+                android:id="@+id/ButtonDiscard"
+                android:textStyle="bold"
+                android:textSize="18sp"
+                android:text="@string/save_discard_button"/>
+        <Button android:layout_height="wrap_content"
+                android:layout_width="fill_parent"
+                android:layout_weight="1"
+                android:drawableLeft="@android:drawable/ic_menu_save"
+                android:id="@+id/ButtonSubmit"
+                android:textStyle="bold"
+                android:textSize="18sp"
+                android:text="@string/save_submit_button"/>
       </LinearLayout>
     </LinearLayout>
   </RelativeLayout>

--- a/libraries/cyclestreets-track/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-track/src/main/res/values/strings.xml
@@ -1,6 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="previous_trips">Saved Trips:</string>
-  <string name="startNewTrip">Start Trip!</string>
-  <string name="finishedButtonLabel">Finish</string>
+  <string name="journey_current_speed">Current Speed:</string>
+  <string name="journey_time">Journey Time:</string>
+  <string name="journey_distance">Distance:</string>
+  <string name="journey_finish_button">Finish</string>
+
+  <string name="completedjourney_info">journey info</string>
+  <string name="completedjourney_start_time">start time</string>
+  <string name="completedjourney_purpose">purpose of trip</string>
+
+  <string name="save_choose_purpose_hint">Finished recording. Choose a trip purpose:</string>
+  <string name="save_purpose_commute">Commute</string>
+  <string name="save_purpose_school">School</string>
+  <string name="save_purpose_work">Work-Related</string>
+  <string name="save_purpose_exercise">Exercise</string>
+  <string name="save_purpose_social">Social</string>
+  <string name="save_purpose_shopping">Shopping</string>
+  <string name="save_purpose_errand">Errand</string>
+  <string name="save_purpose_other">Other</string>
+  <string name="save_wide_blank">"     "</string>
+  <string name="save_trip_comments_hint">Comments about your trip</string>
+  <string name="save_age">Age:</string>
+  <string name="save_gender">Gender:</string>
+
+  <!-- Note to translators: These three strings form the sentence "Level of cycling experience:" -->
+  <string name="save_level_of">Level of</string>
+  <string name="save_cycling">cycling</string>
+  <string name="save_experience">experience:</string>
+
+  <string name="save_submit_button">Submit</string>
+  <string name="save_discard_button">Discard</string>
+
 </resources>

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
@@ -249,7 +249,7 @@ public class AccountDetailsActivity extends Activity
       username_ = username;
       password_ = password;
       
-      progress_ = Dialog.createProgressDialog(context, R.string.signing_in);
+      progress_ = Dialog.createProgressDialog(context, R.string.account_signing_in);
     } // SigninTask
     
     @Override
@@ -336,7 +336,7 @@ public class AccountDetailsActivity extends Activity
       name_ = name;
       email_ = email;
       
-      progress_ = Dialog.createProgressDialog(context, R.string.registering);
+      progress_ = Dialog.createProgressDialog(context, R.string.account_registering);
       } // RegisterTask
     
     @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/FeedbackActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/FeedbackActivity.java
@@ -88,7 +88,7 @@ public class FeedbackActivity extends Activity implements TextWatcher, OnClickLi
       this.name = name;
       this.email = email;
 
-      this.progress = Dialog.createProgressDialog(context, R.string.sending_feedback);
+      this.progress = Dialog.createProgressDialog(context, R.string.feedback_sending);
     }
 
     @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
@@ -176,13 +176,13 @@ public class PhotoUploadActivity extends Activity
     }
     
     photoCategory_ = inflater_.inflate(R.layout.addphotocategory, null);
-    backNextButtons(photoCategory_, getString(R.string.photo_back), android.R.drawable.ic_media_rew, getString(R.string.photo_next), android.R.drawable.ic_media_ff);
+    backNextButtons(photoCategory_, getString(R.string.all_button_back), android.R.drawable.ic_media_rew, getString(R.string.all_button_next), android.R.drawable.ic_media_ff);
 
     photoLocation_ = inflater_.inflate(R.layout.addphotolocation, null);
-    backNextButtons(photoLocation_, getString(R.string.photo_back), android.R.drawable.ic_media_rew, getString(R.string.common_upload), android.R.drawable.ic_menu_upload);
+    backNextButtons(photoLocation_, getString(R.string.all_button_back), android.R.drawable.ic_media_rew, getString(R.string.all_upload), android.R.drawable.ic_menu_upload);
 
     photoWebView_ = inflater_.inflate(R.layout.addphotoview, null);
-    backNextButtons(photoWebView_, getString(R.string.photo_upload_another), android.R.drawable.ic_menu_revert, getString(R.string.photo_close), android.R.drawable.ic_menu_close_clear_cancel);
+    backNextButtons(photoWebView_, getString(R.string.photo_upload_another), android.R.drawable.ic_menu_revert, getString(R.string.all_button_close), android.R.drawable.ic_menu_close_clear_cancel);
 
     // start reading categories
     if(photomapCategories == null)
@@ -311,16 +311,16 @@ public class PhotoUploadActivity extends Activity
   @Override
   public boolean onCreateOptionsMenu(final Menu menu)
   {
-    createMenuItem(menu, R.string.ic_menu_restart, Menu.NONE, R.drawable.ic_menu_rotate);
-    createMenuItem(menu, R.string.ic_menu_back, Menu.NONE, R.drawable.ic_menu_revert);
+    createMenuItem(menu, R.string.all_menu_restart, Menu.NONE, R.drawable.ic_menu_rotate);
+    createMenuItem(menu, R.string.all_menu_back, Menu.NONE, R.drawable.ic_menu_revert);
     return true;
   } // onCreateOptionsMenu
   
   @Override
   public boolean onPrepareOptionsMenu(final Menu menu)
   {
-    enableMenuItem(menu, R.string.ic_menu_restart, step_ != AddStep.PHOTO);
-    enableMenuItem(menu, R.string.ic_menu_back, step_ != AddStep.PHOTO && step_ != AddStep.VIEW);
+    enableMenuItem(menu, R.string.all_menu_restart, step_ != AddStep.PHOTO);
+    enableMenuItem(menu, R.string.all_menu_back, step_ != AddStep.PHOTO && step_ != AddStep.VIEW);
     return true;
   } // onPrepareOptionsMenu
     
@@ -329,13 +329,13 @@ public class PhotoUploadActivity extends Activity
   {
     final int menuItem = item.getItemId();
 
-    if(R.string.ic_menu_restart == menuItem) {
+    if(R.string.all_menu_restart == menuItem) {
       step_ = AddStep.PHOTO;
       setupView();
       return true;
     }
 
-    if(R.string.ic_menu_back == menuItem) {
+    if(R.string.all_menu_back == menuItem) {
       onBackPressed();
       return true;
     }
@@ -392,7 +392,7 @@ public class PhotoUploadActivity extends Activity
       // keyboard to hide, if we don't recreate the view afresh, Android won't redisplay 
       // the keyboard if we come back to this view
       photoCaption_ = inflater_.inflate(R.layout.addphotocaption, null);
-      backNextButtons(photoCaption_, getString(R.string.photo_back), android.R.drawable.ic_media_rew, getString(R.string.photo_next), android.R.drawable.ic_media_ff);
+      backNextButtons(photoCaption_, getString(R.string.all_button_back), android.R.drawable.ic_media_rew, getString(R.string.all_button_next), android.R.drawable.ic_media_ff);
       setUploadView(photoCaption_);
       captionEditor().setText(caption_);
       if (photo_ == null && allowTextOnly_) {
@@ -784,7 +784,7 @@ if (url.startsWith("content://com.google.android.apps.photos.content")){
       dateTime_ = dateTime;
       caption_ = caption;
       
-      progress_ = Dialog.createProgressDialog(context, R.string.uploading_photo);
+      progress_ = Dialog.createProgressDialog(context, R.string.photo_uploading);
     } // UploadPhotoTask
     
     @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/PhotoUploadActivity.java
@@ -412,9 +412,9 @@ public class PhotoUploadActivity extends Activity
       setUploadView(photoLocation_);
       there_.recentre();
       if (photo_ == null && allowTextOnly_)
-        ((TextView)photoRoot_.findViewById(R.id.label)).setText(getString(R.string.report_where));
+        ((TextView)photoRoot_.findViewById(R.id.label)).setText(getString(R.string.report_location_hint));
       else
-        ((TextView)photoRoot_.findViewById(R.id.label)).setText(getString(R.string.photo_where));
+        ((TextView)photoRoot_.findViewById(R.id.label)).setText(getString(R.string.photo_location_hint));
       break;
     case VIEW:
       setUploadView(photoWebView_);

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/CycleStreetsRoutingTask.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/CycleStreetsRoutingTask.java
@@ -15,7 +15,7 @@ class CycleStreetsRoutingTask extends RoutingTask<Waypoints>
 				                  final int speed,
 				                  final Context context)
 	{
-	  super(R.string.finding_route, context);
+	  super(R.string.route_finding_new, context);
 		routeType_ = routeType;
 		speed_ = speed;
 	} // NewRouteTask

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/FetchCycleStreetsRouteTask.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/FetchCycleStreetsRouteTask.java
@@ -13,7 +13,7 @@ public class FetchCycleStreetsRouteTask extends RoutingTask<Long>
                              final int speed,
                              final Context context)
   {
-    super(R.string.fetching_route, context);
+    super(R.string.route_fetching_existing, context);
     routeType_ = routeType;
     speed_ = speed;
   } // FetchCycleStreetsRouteTask

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/ReplanRoutingTask.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/ReplanRoutingTask.java
@@ -15,7 +15,7 @@ public class ReplanRoutingTask
 	                  final RouteDatabase db,
 	                  final Context context)
 	{
-		super(R.string.loading_route, context);
+		super(R.string.route_loading, context);
 		db_ = db;
 		newPlan_ = newPlan;
 	} // ReplanRouteTask
@@ -28,7 +28,7 @@ public class ReplanRoutingTask
 	  if(rd != null)
 		  return rd;
 
-	  publishProgress(R.string.finding_route);
+	  publishProgress(R.string.route_finding_new);
 	  return fetchRoute(newPlan_, pr.itinerary(), 0, pr.waypoints());
 	} // doInBackground
 } // class ReplanRoutingTask

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
@@ -144,7 +144,7 @@ public class Route
       return true;
     } // try
     catch(Exception e) {
-      Toast.makeText(context_, R.string.route_failed, Toast.LENGTH_LONG).show();
+      Toast.makeText(context_, R.string.route_finding_failed, Toast.LENGTH_LONG).show();
     }
     return false;
   } // onNewJourney

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/StoredRoutingTask.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/StoredRoutingTask.java
@@ -13,7 +13,7 @@ public class StoredRoutingTask extends RoutingTask<Integer>
 	StoredRoutingTask(final RouteDatabase db,
 	                  final Context context)
 	{
-		super(R.string.loading_route, context);
+		super(R.string.route_loading, context);
 		db_ = db;
 	} // StoredRoutingTask
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
@@ -41,7 +41,7 @@ public class TileSource {
           ((MapsforgeOSMTileSource)renderer).setMapFile(mapFile);
         else {
           MessageBox.YesNo(context,
-              R.string.out_of_date_map_pack,
+              R.string.tiles_map_pack_out_of_date,
               new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface arg0, int arg1) {
                   MapPack.searchGooglePlay(context);

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
@@ -124,19 +124,19 @@ public class LocationOverlay extends MyLocationNewOverlay
   ////////////////////////////////////////////////
   @Override
   public void onCreateOptionsMenu(final Menu menu) {
-    createMenuItem(menu, R.string.ic_menu_mylocation, Menu.NONE, R.drawable.ic_menu_mylocation);
+    createMenuItem(menu, R.string.location_menu_mylocation, Menu.NONE, R.drawable.ic_menu_mylocation);
   } // onCreateOptionsMenu
 
   @Override
   public void onPrepareOptionsMenu(final Menu menu) {
-    final MenuItem item = enableMenuItem(menu, R.string.ic_menu_mylocation, true);
+    final MenuItem item = enableMenuItem(menu, R.string.location_menu_mylocation, true);
     if(item != null)
       item.setTitle(isMyLocationEnabled() ? LOCATION_OFF : LOCATION_ON);
   } // onPrepareOptionsMenu
 
   @Override
   public boolean onMenuItemSelected(final int featureId, final MenuItem item) {
-    if(item.getItemId() != R.string.ic_menu_mylocation)
+    if(item.getItemId() != R.string.location_menu_mylocation)
       return false;
 
     enableAndFollowLocation(!isMyLocationEnabled());

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/POIOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/POIOverlay.java
@@ -361,16 +361,16 @@ public class POIOverlay
   /////////////////////////////////////////////////////
   ////////////////////////////////////////////////
   public void onCreateOptionsMenu(final Menu menu) {
-    createMenuItem(menu, R.string.ic_menu_poi, Menu.NONE, R.drawable.ic_menu_poi);
-    enableMenuItem(menu, R.string.ic_menu_poi, true);
+    createMenuItem(menu, R.string.poi_menu_title, Menu.NONE, R.drawable.ic_menu_poi);
+    enableMenuItem(menu, R.string.poi_menu_title, true);
   } // onCreateOptionsMenu
 
   public void onPrepareOptionsMenu(final Menu menu) {
-    enableMenuItem(menu, R.string.ic_menu_poi, true);
+    enableMenuItem(menu, R.string.poi_menu_title, true);
   } // onPrepareOptionsMenu
 
   public boolean onMenuItemSelected(final int featureId, final MenuItem item) {
-    if(item.getItemId() != R.string.ic_menu_poi)
+    if(item.getItemId() != R.string.poi_menu_title)
       return false;
 
     if(chooserShowing_)
@@ -382,7 +382,7 @@ public class POIOverlay
                                                                  activeCategories_);
 
     Dialog.listViewDialog(context_,
-                          R.string.ic_menu_poi,
+                          R.string.poi_menu_title,
                           poiAdapter,
                           new DialogInterface.OnClickListener() {
                             @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
@@ -301,7 +301,7 @@ public class TapToRouteOverlay extends Overlay
       final Location lastFix = mapView_.getLastFix();
       if(lastFix == null)
       {
-        Toast.makeText(mapView_.getContext(), R.string.no_location, Toast.LENGTH_LONG).show();
+        Toast.makeText(mapView_.getContext(), R.string.route_no_location, Toast.LENGTH_LONG).show();
         return true;
       } // if ...
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/TapToRouteOverlay.java
@@ -58,15 +58,15 @@ public class TapToRouteOverlay extends Overlay
                                           PauseResumeListener,
                                           Route.Listener
 {
-  private static int[] Replan_Menu_Ids = { R.string.ic_menu_replan_quietest,
-                                           R.string.ic_menu_replan_balanced,
-                                           R.string.ic_menu_replan_fastest,
-                                           R.string.ic_menu_replan_shortest };
+  private static int[] Replan_Menu_Ids = { R.string.route_menu_change_replan_quietest,
+                                           R.string.route_menu_change_replan_balanced,
+                                           R.string.route_menu_change_replan_fastest,
+                                           R.string.route_menu_change_replan_shortest};
   private static Map<Integer, String> Replan_Menu_Plans =
-      Collections.map(R.string.ic_menu_replan_quietest, RoutePlans.PLAN_QUIETEST)
-                 .map(R.string.ic_menu_replan_balanced, RoutePlans.PLAN_BALANCED)
-                 .map(R.string.ic_menu_replan_fastest, RoutePlans.PLAN_FASTEST)
-                 .map(R.string.ic_menu_replan_shortest, RoutePlans.PLAN_SHORTEST);
+      Collections.map(R.string.route_menu_change_replan_quietest, RoutePlans.PLAN_QUIETEST)
+                 .map(R.string.route_menu_change_replan_balanced, RoutePlans.PLAN_BALANCED)
+                 .map(R.string.route_menu_change_replan_fastest, RoutePlans.PLAN_FASTEST)
+                 .map(R.string.route_menu_change_replan_shortest, RoutePlans.PLAN_SHORTEST);
 
   private final Drawable greenWisp_;
   private final Drawable orangeWisp_;
@@ -253,13 +253,13 @@ public class TapToRouteOverlay extends Overlay
   @Override
   public void onCreateOptionsMenu(final Menu menu)
   {
-    createMenuItem(menu, R.string.ic_menu_replan, Menu.FIRST, R.drawable.ic_menu_more);
+    createMenuItem(menu, R.string.route_menu_change, Menu.FIRST, R.drawable.ic_menu_more);
   } // onCreateOptionsMenu
 
   @Override
   public void onPrepareOptionsMenu(final Menu menu)
   {
-    showMenuItem(menu, R.string.ic_menu_replan, tapState_ == TapToRoute.ALL_DONE);
+    showMenuItem(menu, R.string.route_menu_change, tapState_ == TapToRoute.ALL_DONE);
   } // onPrepareOptionsMenu
 
   @Override
@@ -273,10 +273,10 @@ public class TapToRouteOverlay extends Overlay
       if(!currentPlan.equals(Replan_Menu_Plans.get(id)))
         createMenuItem(menu, id);
     if(mapView_.isMyLocationEnabled())
-      createMenuItem(menu, R.string.ic_menu_reroute_from_here);
-    createMenuItem(menu, R.string.ic_menu_reverse);
-    createMenuItem(menu, R.string.ic_menu_share);
-    createMenuItem(menu, R.string.ic_menu_feedback);
+      createMenuItem(menu, R.string.route_menu_change_reroute_from_here);
+    createMenuItem(menu, R.string.route_menu_change_reverse);
+    createMenuItem(menu, R.string.route_menu_change_share);
+    createMenuItem(menu, R.string.route_menu_change_comment);
   } // onCreateContextMenu
 
   @Override
@@ -284,7 +284,7 @@ public class TapToRouteOverlay extends Overlay
   {
     final int menuId = item.getItemId();
 
-    if(menuId == R.string.ic_menu_replan)
+    if(menuId == R.string.route_menu_change)
     {
       mapView_.showContextMenu();
       return true;
@@ -296,7 +296,7 @@ public class TapToRouteOverlay extends Overlay
       return true;
     } // if ...
 
-    if(R.string.ic_menu_reroute_from_here == menuId)
+    if(R.string.route_menu_change_reroute_from_here == menuId)
     {
       final Location lastFix = mapView_.getLastFix();
       if(lastFix == null)
@@ -309,18 +309,18 @@ public class TapToRouteOverlay extends Overlay
                                          (int)(lastFix.getLongitude() * 1E6));
       onRouteNow(Waypoints.fromTo(from, finish()));
     }
-    if(R.string.ic_menu_reverse == menuId) {
+    if(R.string.route_menu_change_reverse == menuId) {
       onRouteNow(waypoints().reversed());
       return true;
     }
-    if(R.string.ic_menu_share == menuId) {
+    if(R.string.route_menu_change_share == menuId) {
       Share.Url(mapView_,
           Route.journey().url(),
           Route.journey().name(),
           "CycleStreets journey");
       return true;
     }
-    if(R.string.ic_menu_feedback == menuId) {
+    if(R.string.route_menu_change_comment == menuId) {
       final Context context = mapView_.getContext();
       context.startActivity(new Intent(context, FeedbackActivity.class));
       return true;

--- a/libraries/cyclestreets-view/src/main/res/layout/accountdetails.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/accountdetails.xml
@@ -6,34 +6,34 @@
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<TextView 
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center"
-		android:text="@string/account_required"
+		android:text="@string/account_required_for_photos"
 		/>
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<TextView 
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center"
-		android:text="@string/account_registering_free"
+		android:text="@string/account_registering_is_free"
 		/>		
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<Button android:id="@+id/newaccount_button"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/account_register"/>
+		android:text="@string/account_register_message"/>
 	<Button android:id="@+id/existingaccount_button"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"

--- a/libraries/cyclestreets-view/src/main/res/layout/accountregister.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/accountregister.xml
@@ -15,21 +15,21 @@
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView 
 	  android:id="@+id/registration_message"
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
 	  android:gravity="center"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/common_your_name"/>
+	  android:text="@string/all_your_name"/>
       <EditText
 	  android:id="@+id/name"
 	  android:layout_height="wrap_content" 
@@ -38,7 +38,7 @@
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/common_your_email"/>
+	  android:text="@string/all_your_email"/>
       <EditText
 	  android:id="@+id/email"
 	  android:layout_height="wrap_content" 
@@ -47,7 +47,7 @@
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"

--- a/libraries/cyclestreets-view/src/main/res/layout/accountsignin.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/accountsignin.xml
@@ -15,7 +15,7 @@
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView 
 	  android:id="@+id/signin_message"
 	  android:layout_width="fill_parent"
@@ -25,7 +25,7 @@
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/blank"/>
+	  android:text="@string/all_blank"/>
       <TextView
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
@@ -56,12 +56,12 @@
 	android:layout_width="0dip"
 	android:layout_height="wrap_content"
 	android:layout_weight="1"     	
-	android:text="@string/account_clear_stored"/>
+	android:text="@string/account_clear_stored_button"/>
     <Button
 	android:id="@+id/signin_button"
 	android:layout_width="0dip"
 	android:layout_height="wrap_content"
 	android:layout_weight="1"     	
-	android:text="@string/account_signin"/>
+	android:text="@string/account_signin_button"/>
   </LinearLayout>       
 </LinearLayout>

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotocaption.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotocaption.xml
@@ -20,7 +20,7 @@
 	  	<TextView
 			android:layout_width="fill_parent"
 			android:layout_height="wrap_content"
-			android:text="@string/photo_describe"
+			android:text="@string/photo_describe_hint"
       android:id="@+id/label"/>
 		<EditText
 			android:id="@+id/caption"

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotocategory.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotocategory.xml
@@ -20,7 +20,7 @@
 	  	<TextView
 			android:layout_width="fill_parent"
 			android:layout_height="wrap_content"
-			android:text="@string/photo_good_or_bad"/>
+			android:text="@string/photo_good_or_bad_hint"/>
 		<Spinner 
 			android:id="@+id/metacat"
 			android:layout_width="fill_parent" 
@@ -28,7 +28,7 @@
 	  	<TextView
 			android:layout_width="fill_parent"
 			android:layout_height="wrap_content"
-			android:text="@string/photo_what_feature_type"/>
+			android:text="@string/photo_feature_type_hint"/>
 		<Spinner 
 			android:id="@+id/category"
 			android:layout_width="fill_parent" 

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotolocation.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotolocation.xml
@@ -15,12 +15,12 @@
     android:gravity="center"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:text="@string/photo_where"/>
+    android:text="@string/photo_location_hint"/>
   <TextView
     android:id="@+id/nogeo"
     android:gravity="center"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:text="@string/photo_not_geolocatable"/>
+    android:text="@string/photo_not_geolocatable_hint"/>
 	<include layout="@layout/addphotonext"/>
 </LinearLayout>

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotonext.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotonext.xml
@@ -5,14 +5,14 @@
 	android:gravity="bottom">
 
 	<Button
-		android:text="@string/photo_back"
+		android:text="@string/all_button_back"
 		android:id="@+id/back"
 		android:layout_height="wrap_content"
 		android:layout_weight="1.0"
 		android:layout_width="30dip"/>
 
 	<Button
-		android:text="@string/photo_next"
+		android:text="@string/all_button_next"
 		android:id="@+id/next"
 		android:layout_height="wrap_content"
 		android:layout_weight="1.0"

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotostart.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotostart.xml
@@ -5,7 +5,7 @@
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<TextView android:id="@+id/addphoto_text"
 		android:layout_width="fill_parent"
@@ -16,7 +16,7 @@
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<TextView android:id="@+id/addphoto_text2"
 		android:layout_width="fill_parent"
@@ -27,7 +27,7 @@
 	<TextView
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/blank"
+		android:text="@string/all_blank"
 		/>
 	<Button android:id="@+id/takephoto_button"
 		android:layout_width="fill_parent"
@@ -41,7 +41,7 @@
   <TextView
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:text="@string/blank"
+    android:text="@string/all_blank"
     android:id="@+id/textView"
     android:layout_gravity="center_horizontal"/>
 

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotostart.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotostart.xml
@@ -11,7 +11,7 @@
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center"
-		android:text="@string/photo_upload_title"
+		android:text="@string/photo_upload_hint1"
 		/>
 	<TextView
 		android:layout_width="fill_parent"
@@ -22,7 +22,7 @@
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center"
-		android:text="@string/photo_upload_subtitle"
+		android:text="@string/photo_upload_hint2"
 		/>		
 	<TextView
 		android:layout_width="fill_parent"
@@ -32,11 +32,11 @@
 	<Button android:id="@+id/takephoto_button"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/photo_take"/>
+		android:text="@string/photo_take_button"/>
 	<Button android:id="@+id/chooseexisting_button"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="@string/photo_select_existing"/>
+		android:text="@string/photo_select_button"/>
 
   <TextView
     android:layout_width="wrap_content"
@@ -50,5 +50,5 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_horizontal"
-    android:text="@string/photo_continue_without"/>
+    android:text="@string/report_continue_without_photo_button"/>
 </LinearLayout>

--- a/libraries/cyclestreets-view/src/main/res/layout/addphotoview.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/addphotoview.xml
@@ -22,7 +22,7 @@
 		<TextView
 		    android:layout_height="wrap_content" 
 			android:layout_width="fill_parent"
-		    android:text="@string/blank"/>
+		    android:text="@string/all_blank"/>
 		<TextView 
 			android:id="@+id/photo_url"
 			android:gravity="center"

--- a/libraries/cyclestreets-view/src/main/res/layout/journey_type.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/journey_type.xml
@@ -11,7 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:text="@string/journey_route_type"
+        android:text="@string/route_type"
         />
     <Spinner
         android:id="@+id/routeTypeSpinner"

--- a/libraries/cyclestreets-view/src/main/res/layout/journey_type.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/journey_type.xml
@@ -11,7 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:text="@string/route_type"
+        android:text="@string/journey_route_type"
         />
     <Spinner
         android:id="@+id/routeTypeSpinner"

--- a/libraries/cyclestreets-view/src/main/res/layout/poicategories_item.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/poicategories_item.xml
@@ -19,7 +19,7 @@
         android:layout_centerVertical="true"
         android:gravity="center_vertical"
         android:ellipsize="marquee"
-        android:text="@string/poi_category"
+        android:text="@string/poi_menu_entry"
       />
     <CheckBox 
       android:id="@+id/checkbox"

--- a/libraries/cyclestreets-view/src/main/res/layout/routefeedback.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/routefeedback.xml
@@ -29,7 +29,7 @@
       <TextView 
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/common_your_name"/>
+	  android:text="@string/all_your_name"/>
       <EditText 
 	  android:id="@+id/name"
 	  android:layout_width="fill_parent"
@@ -38,7 +38,7 @@
       <TextView 
 	  android:layout_width="fill_parent"
 	  android:layout_height="wrap_content"
-	  android:text="@string/common_your_email"/>
+	  android:text="@string/all_your_email"/>
       <EditText 
 	  android:id="@+id/email"
 	  android:layout_width="fill_parent"
@@ -55,7 +55,7 @@
 	android:layout_width="0.0dip"
 	android:layout_height="fill_parent"
 	android:layout_weight="1"/>				
-    <Button android:text="@string/common_upload"
+    <Button android:text="@string/all_upload"
 	    android:id="@+id/upload" 
 	    android:layout_height="wrap_content" 
 	    android:layout_weight="1" 

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -2,28 +2,28 @@
 <resources>
   <string name="app_name">CycleStreets</string>
 
-  <string name="blank" translatable="false">"  "</string>
+  <string name="all_blank" translatable="false">"  "</string>
 
-  <string name="finding_route">Obtaining route from CycleStreets.net, please wait</string>
-  <string name="fetching_route">Fetching route from CycleStreets.net, please wait</string>
-  <string name="route_failed">Route finding failed</string>
-  <string name="loading_route">Loading route, please wait</string>
-  <string name="uploading_photo">Uploading report, please wait</string>
+  <string name="route_finding_new">Obtaining route from CycleStreets.net, please wait</string>
+  <string name="route_fetching_existing">Fetching route from CycleStreets.net, please wait</string>
+  <string name="route_finding_failed">Route finding failed</string>
+  <string name="route_loading">Loading route, please wait</string>
+  <string name="photo_uploading">Uploading report, please wait</string>
 
-  <string name="ic_menu_replan">Change route type</string>
-  <string name="ic_menu_reverse">Reverse route</string>
-  <string name="ic_menu_share">Share this route</string>
-  <string name="ic_menu_feedback">Comment on this route</string>
-  <string name="ic_menu_replan_fastest">Replan as fastest</string>
-  <string name="ic_menu_replan_balanced">Replan as balanced</string>
-  <string name="ic_menu_replan_quietest">Replan as quietest</string>
-  <string name="ic_menu_replan_shortest">Replan as shortest</string>
-  <string name="ic_menu_reroute_from_here">Reroute from current location</string>
+  <string name="route_menu_change">Change route type</string>
+  <string name="route_menu_change_reverse">Reverse route</string>
+  <string name="route_menu_change_share">Share this route</string>
+  <string name="route_menu_change_comment">Comment on this route</string>
+  <string name="route_menu_change_replan_fastest">Replan as fastest</string>
+  <string name="route_menu_change_replan_balanced">Replan as balanced</string>
+  <string name="route_menu_change_replan_quietest">Replan as quietest</string>
+  <string name="route_menu_change_replan_shortest">Replan as shortest</string>
+  <string name="route_menu_change_reroute_from_here">Reroute from current location</string>
 
-  <string name="ic_menu_restart">Start again</string>
-  <string name="ic_menu_back">Back</string>
+  <string name="all_menu_restart">Start again</string>
+  <string name="all_menu_back">Back</string>
 
-  <string name="no_location">Location not currently available.</string>
+  <string name="route_no_location">Location not currently available.</string>
 
   <string name="photo_upload_title">Upload reports of cycling-related problems or of good practice.</string>
   <string name="photo_upload_subtitle">These will be used so that we can report problems to decision makers.</string>
@@ -34,18 +34,18 @@
   <string name="photo_good_or_bad">Is this a problem or good practice?</string>
   <string name="photo_what_feature_type">What type of feature is being shown</string>
   <string name="photo_share">Share this photo</string>
-  <string name="photo_back">Back</string>
-  <string name="photo_next">Next</string>
-  <string name="photo_close">Close</string>
+  <string name="all_button_back">Back</string>
+  <string name="all_button_next">Next</string>
+  <string name="all_button_close">Close</string>
   <string name="photo_upload_another">Upload another</string>
   <string name="photo_where">Where was this photo taken?</string>
   <string name="photo_not_geolocatable">The photo could not be geolocated. To automatically locate photos, please turn on geolocation in your Camera settings.</string>
   <string name="report_title">Your Report</string>
   <string name="report_where">Where is the location your report describes?</string>
 
-  <string name="out_of_date_map_pack">This map pack is cannot be used with this version of the app. \n\nWould you like to search for an update?</string>
+  <string name="tiles_map_pack_out_of_date">This map pack is cannot be used with this version of the app. \n\nWould you like to search for an update?</string>
 
-  <string name="ic_menu_mylocation">Show location</string>
+  <string name="location_menu_mylocation">Show location</string>
 
   <string name="placeview_menu">Menu</string>
   <string name="placeview_current_location">Current Location</string>
@@ -58,28 +58,27 @@
   <string name="placeview_remove">Remove</string>
   <string name="placeview_saved_locations">Saved Locations</string>
 
-  <string name="ic_menu_poi">Points of Interest</string>
-  <string name="ic_menu_poi_clear_all">Clear all</string>
+  <string name="poi_menu_title">Points of Interest</string>
 
-  <string name="signing_in">Signing into CycleStreets.net</string>
-  <string name="registering">Registering with CycleStreets.net</string>
-  <string name="sending_feedback">Sending route feedback to CycleStreets.net</string>
+  <string name="account_signing_in">Signing into CycleStreets.net</string>
+  <string name="account_registering">Registering with CycleStreets.net</string>
+  <string name="feedback_sending">Sending route feedback to CycleStreets.net</string>
 
-  <string name="no_map_packs">You do not have any map packs installed.  Vector maps for
+  <string name="settings_no_map_packs">You do not have any map packs installed.  Vector maps for
 	    offline use are available as separate downloads.
 	    \n\nWould you like to search for map packs now?</string>
   <string name="settings_signed_in">Signed in to CycleStreets</string>
   <string name="settings_awaiting">Account registration awaiting verification</string>
 
-  <string name="common_upload">Upload!</string>
-  <string name="common_your_name">Your name</string>
-  <string name="common_your_email">Your email address</string>
+  <string name="all_upload">Upload!</string>
+  <string name="all_your_name">Your name</string>
+  <string name="all_your_email">Your email address</string>
 
   <string name="feedback_your_comments">Your comments</string>
 
-  <string name="account_required">To upload photos you must have a CycleStreets signin account.</string>
-  <string name="account_registering_free">Registering for an account is free.</string>
-  <string name="account_register">Register for an account</string>
+  <string name="account_required_for_photos">To upload photos you must have a CycleStreets signin account.</string>
+  <string name="account_registering_is_free">Registering for an account is free.</string>
+  <string name="account_register_message">Register for an account</string>
   <string name="account_signin_with_existing">Signin with an existing account</string>
   <string name="account_desired_username">Desired username</string>
   <string name="account_desired_password">Desired password</string>
@@ -89,10 +88,10 @@
   <string name="account_signin_message">Please enter your account username and password to sign in.</string>
   <string name="account_username">Username</string>
   <string name="account_password">Password</string>
-  <string name="account_clear_stored">Clear stored details</string>
-  <string name="account_signin">Sign in</string>
+  <string name="account_clear_stored_button">Clear stored details</string>
+  <string name="account_signin_button">Sign in</string>
 
-  <string name="route_type">Route type</string>
-  <string name="poi_category">category</string>
+  <string name="journey_route_type">Route type</string>
+  <string name="poi_menu_entry">category</string>
 
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -3,12 +3,22 @@
   <string name="app_name">CycleStreets</string>
 
   <string name="all_blank" translatable="false">"  "</string>
+  <string name="all_button_back">Back</string>
+  <string name="all_button_next">Next</string>
+  <string name="all_button_close">Close</string>
+  <string name="all_menu_back">Back</string>
+  <string name="all_menu_restart">Start again</string>
+  <string name="all_upload">Upload!</string>
+  <string name="all_your_name">Your name</string>
+  <string name="all_your_email">Your email address</string>
 
+  <string name="location_menu_mylocation">Show location</string>
+
+  <string name="route_type">Route type</string>
   <string name="route_finding_new">Obtaining route from CycleStreets.net, please wait</string>
   <string name="route_fetching_existing">Fetching route from CycleStreets.net, please wait</string>
   <string name="route_finding_failed">Route finding failed</string>
   <string name="route_loading">Loading route, please wait</string>
-  <string name="photo_uploading">Uploading report, please wait</string>
 
   <string name="route_menu_change">Change route type</string>
   <string name="route_menu_change_reverse">Reverse route</string>
@@ -20,32 +30,26 @@
   <string name="route_menu_change_replan_shortest">Replan as shortest</string>
   <string name="route_menu_change_reroute_from_here">Reroute from current location</string>
 
-  <string name="all_menu_restart">Start again</string>
-  <string name="all_menu_back">Back</string>
-
   <string name="route_no_location">Location not currently available.</string>
 
-  <string name="photo_upload_title">Upload reports of cycling-related problems or of good practice.</string>
-  <string name="photo_upload_subtitle">These will be used so that we can report problems to decision makers.</string>
-  <string name="photo_continue_without">Continue without photo</string>
-  <string name="photo_take">Take a photo</string>
-  <string name="photo_select_existing">Select existing photo</string>
-  <string name="photo_describe">Describe this photo</string>
-  <string name="photo_good_or_bad">Is this a problem or good practice?</string>
-  <string name="photo_what_feature_type">What type of feature is being shown</string>
+  <string name="photo_upload_hint1">Upload reports of cycling-related problems or of good practice.</string>
+  <string name="photo_upload_hint2">These will be used so that we can report problems to decision makers.</string>
+  <string name="photo_take_button">Take a photo</string>
+  <string name="photo_select_button">Select existing photo</string>
+  <string name="photo_describe_hint">Describe this photo</string>
+  <string name="photo_good_or_bad_hint">Is this a problem or good practice?</string>
+  <string name="photo_feature_type_hint">What type of feature is being shown?</string>
+  <string name="photo_location_hint">Where was this photo taken?</string>
+  <string name="photo_not_geolocatable_hint">The photo could not be geolocated. To automatically locate photos, please turn on geolocation in your Camera settings.</string>
   <string name="photo_share">Share this photo</string>
-  <string name="all_button_back">Back</string>
-  <string name="all_button_next">Next</string>
-  <string name="all_button_close">Close</string>
+  <string name="photo_uploading">Uploading report, please wait</string>
   <string name="photo_upload_another">Upload another</string>
-  <string name="photo_where">Where was this photo taken?</string>
-  <string name="photo_not_geolocatable">The photo could not be geolocated. To automatically locate photos, please turn on geolocation in your Camera settings.</string>
+
+  <string name="report_continue_without_photo_button">Continue without photo</string>
   <string name="report_title">Your Report</string>
-  <string name="report_where">Where is the location your report describes?</string>
+  <string name="report_location_hint">Where is the location your report describes?</string>
 
   <string name="tiles_map_pack_out_of_date">This map pack is cannot be used with this version of the app. \n\nWould you like to search for an update?</string>
-
-  <string name="location_menu_mylocation">Show location</string>
 
   <string name="placeview_menu">Menu</string>
   <string name="placeview_current_location">Current Location</string>
@@ -59,10 +63,7 @@
   <string name="placeview_saved_locations">Saved Locations</string>
 
   <string name="poi_menu_title">Points of Interest</string>
-
-  <string name="account_signing_in">Signing into CycleStreets.net</string>
-  <string name="account_registering">Registering with CycleStreets.net</string>
-  <string name="feedback_sending">Sending route feedback to CycleStreets.net</string>
+  <string name="poi_menu_entry">category</string>
 
   <string name="settings_no_map_packs">You do not have any map packs installed.  Vector maps for
 	    offline use are available as separate downloads.
@@ -70,11 +71,8 @@
   <string name="settings_signed_in">Signed in to CycleStreets</string>
   <string name="settings_awaiting">Account registration awaiting verification</string>
 
-  <string name="all_upload">Upload!</string>
-  <string name="all_your_name">Your name</string>
-  <string name="all_your_email">Your email address</string>
-
   <string name="feedback_your_comments">Your comments</string>
+  <string name="feedback_sending">Sending route feedback to CycleStreets.net</string>
 
   <string name="account_required_for_photos">To upload photos you must have a CycleStreets signin account.</string>
   <string name="account_registering_is_free">Registering for an account is free.</string>
@@ -84,14 +82,13 @@
   <string name="account_desired_password">Desired password</string>
   <string name="account_confirm_password">Confirm password</string>
   <string name="account_register_button">Register</string>
+  <string name="account_registering">Registering with CycleStreets.net</string>
 
   <string name="account_signin_message">Please enter your account username and password to sign in.</string>
   <string name="account_username">Username</string>
   <string name="account_password">Password</string>
   <string name="account_clear_stored_button">Clear stored details</string>
   <string name="account_signin_button">Sign in</string>
-
-  <string name="journey_route_type">Route type</string>
-  <string name="poi_menu_entry">category</string>
+  <string name="account_signing_in">Signing into CycleStreets.net</string>
 
 </resources>


### PR DESCRIPTION
As part of addressing #160, this PR removes hardcoded strings from the `cyclestreets-view` and `cyclestreets-track` modules, as well as switching to the naming convention discussed in that issue.

Subsequent PRs will address the other libraries and the main app.