### PR TITLE
Remove workaround for endpoints that now return valid Cache-Control headers

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RewriteCacheControlInterceptor.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RewriteCacheControlInterceptor.java
@@ -13,18 +13,14 @@ import okhttp3.Response;
  *
  * OkHttp automatically caches according to the settings specified by the Cache-Control header in
  * a server response.  Ideally, the server should be updated to return meaningful Cache-Control
- * headers.  In the absence of this change, we have to set our own in this network interceptor.
- * 
- * A half-way solution for some endpoints may be to use the `validuntil` field in the JSON
- * response, if one exists.
+ * headers for all cacheable endpoints.  Where this can't or has yet to be done, we set our own
+ * in this network interceptor.
  */
 public class RewriteCacheControlInterceptor implements Interceptor {
 
   private static final int SECONDS_PER_DAY = 86400;
   private final Map<String, Integer> cacheDurationMap = new HashMap<String, Integer>() {{
-    put("/blog/feed/", 1 * SECONDS_PER_DAY);
-    put("/v2/photomap.categories", 7 * SECONDS_PER_DAY);
-    put("/v2/pois.types", 7 * SECONDS_PER_DAY);
+    put("/blog/feed/", 1 * SECONDS_PER_DAY); // This comes from Wordpress.
   }};
 
   @Override

--- a/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/RetrofitApiClientTest.java
+++ b/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/RetrofitApiClientTest.java
@@ -105,6 +105,7 @@ public class RetrofitApiClientTest {
             .willReturn(aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
+                    .withHeader("Cache-Control", "public, max-age=604800")
                     .withBodyFile("pois-types.json")));
 
     // when
@@ -393,6 +394,7 @@ public class RetrofitApiClientTest {
             .willReturn(aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
+                    .withHeader("Cache-Control", "public, max-age=1209600")
                     .withBodyFile("photomap-categories.json")));
 
     // when


### PR DESCRIPTION
As discussed in #144 we can now remove some of this workaround logic.