### PR TITLE
Use number of commits on branch as the version code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 sudo: false
 dist: trusty
 
+# Get the full commit history (required to derive our version code, see the root build.gradle)
+git:
+  depth: false
+
 language: android
 jdk:
   - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ def manifestProperties(project) {
 def versionProperties(project) {
   // Get the version name.  We increment this manually after pushing beta releases to Production.
   def versionProperties = project.file("version.properties")
-  vName = loadProperties(versionProperties)['versionName']
+  def vName = loadProperties(versionProperties)['versionName']
 
   // For the numerical version code, we use the number of commits on the branch.  Since we don't
   // intend to rewrite history on `master`, this will always be a monotonically increasing number.

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:3.1.2'
     classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
+    classpath 'org.ajoberstar:grgit:2.2.0'
   }
 }
 
@@ -92,17 +93,20 @@ def manifestProperties(project) {
 } // manifestProperties
 
 def versionProperties(project) {
-  def versionDetails = project.file("version.properties")
-  def versionConfig = [ versionCode: "-1", versionName: "unknown" ]
-  if (versionDetails.exists())
-    versionConfig = loadProperties(versionDetails)
-  else
-    println ":${project.name}:No version.properties, using placeholder defaults"
+  // Get the version name.  We increment this manually after pushing beta releases to Production.
+  def versionProperties = project.file("version.properties")
+  vName = loadProperties(versionProperties)['versionName']
+
+  // For the numerical version code, we use the number of commits on the branch.  Since we don't
+  // intend to rewrite history on `master`, this will always be a monotonically increasing number.
+  def git = org.ajoberstar.grgit.Grgit.open()
+  def vCode = git.log().size()
+  println "Version name: ${vName}, code: ${vCode}"
 
   project.android {
     defaultConfig {
-      versionCode versionConfig['versionCode'].toInteger()
-      versionName versionConfig['versionName']
+      versionCode vCode
+      versionName vName
     }
   } // android
 } // versionProperties

--- a/cyclestreets.app/version.properties
+++ b/cyclestreets.app/version.properties
@@ -1,3 +1,2 @@
 # app version
-versionCode=27
 versionName=3.7


### PR DESCRIPTION
Connects to #179.

The Play store APIs only accept an APK submission if the versionCode (an integer) has not already been used. You can see an example failure here:

>```
>:cyclestreets.app:publishApkRelease FAILED
>FAILURE: Build failed with an exception.
>* What went wrong:
>Execution failed for task ':cyclestreets.app:publishApkRelease'.
>> com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
>  {
>    "code" : 403,
>    "errors" : [ {
>      "domain" : "androidpublisher",
>      "message" : "APK specifies a version code that has already been used.",
>      "reason" : "apkUpgradeVersionConflict"
>    } ],
>    "message" : "APK specifies a version code that has already been used."
>  }
>```

Therefore, versionCode has to be monotonically increasing.

The most logical way I could come up with for deriving a monotonically increasing number for our CI builds was to use the number of commits.  On the `master` branch (which is the only branch that will attempt to push to the Play store anyway), this number should never go down, assuming that we don't intend to rewrite history.