### PR TITLE
Stop leaking from LiveRide (and some other improvements)

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -2,9 +2,10 @@
   <ul>
     <li>Migrating towards Material design</li>
     <li>Added translations: Deutsch, Español, Français, हिन्दी, Italiano, मराठी, Português, Русский, Türkçe</li>
-    <li>Show total elevation gain/loss in the Itinerary/Elevation views</li>
-    <li>Round max/min of elevation graphs to make them more readable</li>
+    <li>Improved Elevation views: show total elevation gain/loss, improve scale</li>
     <li>Add phone and opening hours, where available, to POI bubbles</li>
+    <li>Pebble is no longer supported</li>
+    <li>Various minor improvements and fixes</li>
   </ul>
 
   <h3>Release 3.5</h3>

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/RecordingService.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/RecordingService.java
@@ -256,7 +256,7 @@ public class RecordingService extends Service implements LocationListener {
             .setContentTitle("Cycle Hackney - Recording")
             .setContentText("Tap to see your ongoing trip")
             .setContentIntent(contentIntent)
-            .getNotification();
+            .build();
     notification.flags = flags;
     return notification;
   }

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripDataUploader.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripDataUploader.java
@@ -153,7 +153,7 @@ public class TripDataUploader extends AsyncTask<Void, Void, Boolean> {
             .setContentTitle("Cycle Hackney")
             .setContentText(text)
             .setContentIntent(contentIntent)
-            .getNotification();
+            .build();
     notification.flags = flags;
     return notification;
   }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/Arrivee.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/Arrivee.java
@@ -6,9 +6,11 @@ import org.osmdroid.util.GeoPoint;
 
 final class Arrivee extends LiveRideState
 {
+  public static final String ARRIVERAI = "Arreeve eh";
+
   Arrivee(final LiveRideState previous) {
     super(previous);
-    notify("Arreeve eh", "Arriv\u00e9e");
+    notify(ARRIVERAI, "Arriv\u00e9e");
   }
 
   @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideService.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideService.java
@@ -54,6 +54,10 @@ public class LiveRideService extends Service implements LocationListener
   }
 
   public void stopRiding() {
+    if (stage_.isStopped())
+      return;
+    stage_.tts().stop();
+    stage_.tts().shutdown();
     stage_ = LiveRideState.StoppedState(this);
     locationManager_.removeUpdates(this);
   }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.java
@@ -87,7 +87,7 @@ public abstract class LiveRideState
             .setContentTitle(title_)
             .setContentText(text)
             .setContentIntent(contentIntent)
-            .getNotification();
+            .build();
 
     nm.notify(NOTIFICATION_ID, notification);
   }
@@ -102,6 +102,6 @@ public abstract class LiveRideState
 
   private void speak(final String words) {
     String toSpeak = words.replace("LiveRide", "Live Ride");
-    tts().speak(toSpeak, TextToSpeech.QUEUE_ADD, null);
+    tts().speak(toSpeak, TextToSpeech.QUEUE_ADD, null, null);
   }
 }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.java
@@ -18,10 +18,13 @@ import android.util.Log;
 public abstract class LiveRideState
 {
   private static final int NOTIFICATION_ID = 1;
+
+  private final Context context_;
+  private final TextToSpeech tts_;
+  private String title_;
+
   public static LiveRideState InitialState(final Context context) {
-    final TextToSpeech tts = new TextToSpeech(context,
-          new TextToSpeech.OnInitListener() { public void onInit(int arg0) { } }
-    );
+    final TextToSpeech tts = new TextToSpeech(context, arg0 -> { });
     return new LiveRideStart(context, tts);
   }
 
@@ -29,10 +32,6 @@ public abstract class LiveRideState
     return new Stopped(context);
   }
   //////////////////////////////////////////
-
-  private Context context_;
-  private String title_;
-  private TextToSpeech tts_;
 
   protected LiveRideState(final Context context, final TextToSpeech tts) {
     context_ = context;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/NearingTurn.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/NearingTurn.java
@@ -10,8 +10,9 @@ final class NearingTurn extends MovingState
   NearingTurn(final LiveRideState previous, final Journey journey) {
     super(previous, CycleStreetsPreferences.turnNowDistance());
 
-    final Segment segment = journey.segments().get(journey.activeSegmentIndex()+1);
-    notify("Get ready to " + segment.turn());
+    final Segment segment = journey.segments().get(journey.activeSegmentIndex() + 1);
+    String nextAction = (segment.turn() != null && !segment.turn().isEmpty()) ? segment.turn() : Arrivee.ARRIVERAI;
+    notify("Get ready to " + nextAction);
   }
 
   @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveRideOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveRideOverlay.java
@@ -77,6 +77,7 @@ public class LiveRideOverlay extends Overlay implements ServiceConnection
   public void onDetach(final MapView mapView) {
     if (binding_ != null)
       binding_.stopRiding();
+    activity_.unbindService(this);
 
     super.onDetach(mapView);
   }

--- a/libraries/cyclestreets-view/src/main/res/layout/liveride_buttons.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/liveride_buttons.xml
@@ -14,6 +14,7 @@
         app:fabSize="normal"
         app:borderWidth="12dp"
         app:ico_icon="gmd_lock_open"
+        app:ico_color="?android:textColorSecondary"
         app:backgroundTint="@android:color/background_light"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/libraries/cyclestreets-view/src/main/res/layout/restart_planning_button.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/restart_planning_button.xml
@@ -14,6 +14,7 @@
         app:fabSize="normal"
         app:borderWidth="12dp"
         app:ico_icon="gmd_replay"
+        app:ico_color="?android:textColorSecondary"
         app:backgroundTint="@android:color/background_light"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/libraries/cyclestreets-view/src/main/res/layout/route_highlight_buttons.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/route_highlight_buttons.xml
@@ -19,6 +19,7 @@
             app:fabSize="normal"
             app:borderWidth="12dp"
             app:ico_icon="gmd_chevron_left"
+            app:ico_color="?android:textColorSecondary"
             app:backgroundTint="@android:color/background_light"/>
 
         <android.support.design.widget.FloatingActionButton
@@ -28,6 +29,7 @@
             app:fabSize="normal"
             app:borderWidth="12dp"
             app:ico_icon="gmd_chevron_right"
+            app:ico_color="?android:textColorSecondary"
             app:backgroundTint="@android:color/background_light"/>
 
     </LinearLayout>


### PR DESCRIPTION
Before this change, `logcat` reported the following errors when you exited LiveRide.

```
7-23 11:48:46.499 23132-23132/net.cyclestreets E/ActivityThread: Service net.cyclestreets.liveride.LiveRideService has leaked ServiceConnection android.speech.tts.TextToSpeech$Connection@84f424e that was originally bound here
    android.app.ServiceConnectionLeaked: Service net.cyclestreets.liveride.LiveRideService has leaked ServiceConnection android.speech.tts.TextToSpeech$Connection@84f424e that was originally bound here
        at android.app.LoadedApk$ServiceDispatcher.<init>(LoadedApk.java:1514)
        at android.app.LoadedApk.getServiceDispatcher(LoadedApk.java:1406)
        at android.app.ContextImpl.bindServiceCommon(ContextImpl.java:1589)
        at android.app.ContextImpl.bindService(ContextImpl.java:1541)
        at android.content.ContextWrapper.bindService(ContextWrapper.java:678)
        at android.speech.tts.TextToSpeech.connectToEngine(TextToSpeech.java:810)
        at android.speech.tts.TextToSpeech.initTts(TextToSpeech.java:780)
        at android.speech.tts.TextToSpeech.<init>(TextToSpeech.java:733)
        at android.speech.tts.TextToSpeech.<init>(TextToSpeech.java:712)
        at android.speech.tts.TextToSpeech.<init>(TextToSpeech.java:696)
        at net.cyclestreets.liveride.LiveRideState.InitialState(LiveRideState.java:22)
        at net.cyclestreets.liveride.LiveRideService.startRiding(LiveRideService.java:52)
        at net.cyclestreets.liveride.LiveRideService$Binding.startRiding(LiveRideService.java:71)
        at net.cyclestreets.views.overlay.LiveRideOverlay.onServiceConnected(LiveRideOverlay.java:177)
        at android.app.LoadedApk$ServiceDispatcher.doConnected(LoadedApk.java:1634)
        at android.app.LoadedApk$ServiceDispatcher$RunConnection.run(LoadedApk.java:1663)
        at android.os.Handler.handleCallback(Handler.java:789)
        at android.os.Handler.dispatchMessage(Handler.java:98)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6541)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```

In addition to resolving the above, as part of this PR I have also:
-  fixed some deprecated API usages
-  fixed some colouring of the new buttons - back to the same grey styling that's a bit easier on the eye; it was much more obvious on my phone than on the emulator
-  Fixed the annoying message at the end of the ride that said "Get ready to", to instead say "Get ready to arriverai"