### PR TITLE
Set maximum and minimum zoom levels to more sensible values

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -57,6 +57,8 @@ public class CycleMapView extends FrameLayout
 
     mapView_.setBuiltInZoomControls(false);
     mapView_.setMultiTouchControls(true);
+    mapView_.setMaxZoomLevel(17);
+    mapView_.setMinZoomLevel(2);
 
     overlayBottomIndex_ = getOverlays().size();
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.java
@@ -54,7 +54,7 @@ public class LocationOverlay extends MyLocationNewOverlay {
     mapView_ = mapView;
 
     onColor_ = Theme.lowlightColor(mapView_.getContext());
-    followColor_ = Theme.highlightColor(mapView_.getContext());
+    followColor_ = Theme.highlightColor(mapView_.getContext()) | 0xFF000000;
 
     View overlayView = LayoutInflater.from(mapView_.getContext()).inflate(R.layout.locationbutton, null);
     button_ = overlayView.findViewById(R.id.locationbutton);


### PR DESCRIPTION
Closes #89.

Screenshots show the maximum and minimum zoom levels now supported, which I think are not unreasonable.

Note that while I was dealing with this trivial change, I fixed up the follow-me button "on" highlighting to be clear again, which had been regressed.

![screen shot 2018-07-24 at 14 24 44](https://user-images.githubusercontent.com/6017680/43141346-9662febe-8f4d-11e8-956f-a3164bd92163.png)
![screen shot 2018-07-24 at 14 24 03](https://user-images.githubusercontent.com/6017680/43141347-968822a2-8f4d-11e8-9ae8-55eb49edcaba.png)

