### PR TITLE
Upgrade osmdroid; restrict max/min latitude

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -24,6 +24,7 @@
     <li>Extra start waypoint added when replanning the journey does not persist, so multiple replans are dealt with more logically.</li>
     <li>A number of crash scenarios fixed.</li>
     <li>LiveRide now makes itself a foreground service, which fixes some scenarios where it previously wouldn't work (e.g. low available memory)</li>
+    <li>You can no longer scroll past the North Pole to Antarctica, and back again.</li>
   </ul>
 
   <h3>Release 3.6</h3>

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -6,7 +6,7 @@ configurations {
 dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
-  api 'org.osmdroid:osmdroid-android:6.0.2'
+  api 'org.osmdroid:osmdroid-android:6.0.3'
   api 'org.slf4j:slf4j-android:1.7.25'
 
   api "com.android.support:support-compat:${rootProject.ext.supportLibraryVersion}"

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -6,7 +6,7 @@ configurations {
 dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
-  api 'org.osmdroid:osmdroid-android:5.6.5'
+  api 'org.osmdroid:osmdroid-android:6.0.2'
   api 'org.slf4j:slf4j-android:1.7.25'
 
   api "com.android.support:support-compat:${rootProject.ext.supportLibraryVersion}"

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/JourneyOverlay.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/JourneyOverlay.java
@@ -65,10 +65,10 @@ public class JourneyOverlay extends Overlay {
 
     final IGeoPoint centre = mapView.getMapCenter();
 
-    if (zoomLevel_ != mapView.getZoomLevel() ||
+    if (zoomLevel_ != (int)mapView.getZoomLevelDouble() ||
        !centre.equals(mapCentre_)) {
       ridePath_ = null;
-      zoomLevel_ = mapView.getProjection().getZoomLevel();
+      zoomLevel_ = (int)mapView.getProjection().getZoomLevel();
       mapCentre_ = centre;
     }
 

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/RecordingService.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/RecordingService.java
@@ -296,7 +296,7 @@ public class RecordingService extends Service implements LocationListener {
     for (int i = points.size()-1; i != 0; --i) {
       final CyclePoint cur = points.get(i);
 
-      if (end.distanceTo(cur) > 100)
+      if (end.distanceToAsDouble(cur) > 100)
         return false;
 
       if ((end.time - cur.time) > BAIL_TIME)

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/ShowJourney.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/ShowJourney.java
@@ -34,7 +34,7 @@ public class ShowJourney extends Activity {
     setText(R.id.journey_start, trip.fancyStart());
 
     // zoomToBoundingBox works better if setZoom first
-    mapView_.getController().setZoom(DEFAULT_ZOOM_LEVEL);
+    mapView_.getController().setZoom((double)DEFAULT_ZOOM_LEVEL);
     mapView_.overlayPushTop(JourneyOverlay.CompletedJourneyOverlay(this, mapView_, trip));
   }
 

--- a/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripData.java
+++ b/libraries/cyclestreets-track/src/main/java/net/cyclestreets/track/TripData.java
@@ -192,11 +192,11 @@ public class TripData {
     if (gpspoints.size() > 1) {
       CyclePoint gp = gpspoints.get(gpspoints.size()-1);
 
-      float segmentDistance = gp.distanceTo(pt);
+      double segmentDistance = gp.distanceToAsDouble(pt);
       if (segmentDistance == 0)
         return; // we haven't gone anywhere
 
-      distance += segmentDistance;
+      distance += (float)segmentDistance;
     }
 
     gpspoints.add(pt);

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Segment.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Segment.java
@@ -176,7 +176,7 @@ public abstract class Segment {
     for (int i = 1; i <= minIndex; ++i) {
       final IGeoPoint p1 = points.get(i - 1);
       final IGeoPoint p2 = points.get(i);
-      cumulative += ((GeoPoint)p1).distanceTo(p2);
+      cumulative += ((GeoPoint)p1).distanceToAsDouble(p2);
     }
 
     cumulative += at.offset();

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/UpsizingTileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/UpsizingTileSource.java
@@ -5,7 +5,6 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 
 import org.osmdroid.tileprovider.ExpirableBitmapDrawable;
-import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.tilesource.BitmapTileSourceBase;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
@@ -32,10 +31,12 @@ public class UpsizingTileSource implements ITileSource {
   @Override
   public int getMinimumZoomLevel() { return base_.getMinimumZoomLevel(); }
   @Override
-  public String getTileRelativeFilenameString(MapTile aTile) { return base_.getTileRelativeFilenameString(aTile); }
+  public String getTileRelativeFilenameString(long pMapTileIndex) {
+    return base_.getTileRelativeFilenameString(pMapTileIndex);
+  }
 
-  public String getTileURLString(MapTile aTile) {
-    return online_ != null ? online_.getTileURLString(aTile) : null;
+  public String getTileURLString(long pMapTileIndex) {
+    return online_ != null ? online_.getTileURLString(pMapTileIndex) : null;
   }
 
   @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -82,6 +82,9 @@ public class CycleMapView extends FrameLayout
     mapView_.setMultiTouchControls(true);
     mapView_.setMaxZoomLevel((double)MAX_ZOOM_LEVEL);
     mapView_.setMinZoomLevel(MIN_ZOOM_LEVEL);
+    mapView_.setScrollableAreaLimitLatitude(MapView.getTileSystem().getMaxLatitude(),
+                                            -MapView.getTileSystem().getMaxLatitude(),
+                                            0);
 
     overlayBottomIndex_ = getOverlays().size();
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -44,6 +44,7 @@ public class CycleMapView extends FrameLayout
   public static final int FINDPLACE_ZOOM_LEVEL = 16;
   public static final int ITEM_ZOOM_LEVEL = 16;
   public static final int MAX_ZOOM_LEVEL = 19;
+  public static final double MIN_ZOOM_LEVEL = 2;
   private static final String TAG = Logging.getTag(CycleMapView.class);
 
   private static final String PREFS_APP_CENTRE_LON = "centreLon";
@@ -79,8 +80,8 @@ public class CycleMapView extends FrameLayout
 
     mapView_.setBuiltInZoomControls(false);
     mapView_.setMultiTouchControls(true);
-    mapView_.setMaxZoomLevel(MAX_ZOOM_LEVEL);
-    mapView_.setMinZoomLevel(2);
+    mapView_.setMaxZoomLevel((double)MAX_ZOOM_LEVEL);
+    mapView_.setMinZoomLevel(MIN_ZOOM_LEVEL);
 
     overlayBottomIndex_ = getOverlays().size();
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -237,7 +237,7 @@ public class CycleMapView extends FrameLayout
   public void centreOn(final IGeoPoint place, final int minZoomLevel) {
     centreOn(place);
     if (this.getZoomLevel() < minZoomLevel)
-      getController().setZoom(minZoomLevel);
+      getController().setZoom((double)minZoomLevel);
   }
 
   @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -110,7 +110,7 @@ public class CycleMapView extends FrameLayout
   public List<Overlay> getOverlays() { return mapView_.getOverlays(); }
   public IGeoPoint getMapCenter() { return mapView_.getMapCenter(); }
   private MapTileProviderBase getTileProvider() { return mapView_.getTileProvider(); }
-  public int getZoomLevel() { return mapView_.getZoomLevel(); }
+  public int getZoomLevel() { return (int)mapView_.getZoomLevelDouble(); }
   private Scroller getScroller() { return mapView_.getScroller(); }
   public IMapController getController() { return mapView_.getController(); }
   public BoundingBox getBoundingBox() { return mapView_.getBoundingBox(); }
@@ -184,8 +184,8 @@ public class CycleMapView extends FrameLayout
     getController().setCenter(centre);
     centreOn(centre);
 
-    getController().setZoom(zoom);
     controllerOverlay_.onResume(prefs_);
+    getController().setZoom((double)zoom);
 
     new CountDownTimer(250, 50) {
       public void onTick(long unfinished) { }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -82,9 +82,7 @@ public class CycleMapView extends FrameLayout
     mapView_.setMultiTouchControls(true);
     mapView_.setMaxZoomLevel((double)MAX_ZOOM_LEVEL);
     mapView_.setMinZoomLevel(MIN_ZOOM_LEVEL);
-    mapView_.setScrollableAreaLimitLatitude(MapView.getTileSystem().getMaxLatitude(),
-                                            -MapView.getTileSystem().getMaxLatitude(),
-                                            0);
+    mapView_.setScrollableAreaLimitLatitude(80, -80, 0);
 
     overlayBottomIndex_ = getOverlays().size();
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
@@ -100,7 +100,7 @@ public abstract class LiveItemOverlay<T extends OverlayItem>
   public boolean onZoom(final ZoomEvent event) {
     if (event.getZoomLevel() < zoomLevel_)
       items().clear();
-    zoomLevel_ = event.getZoomLevel();
+    zoomLevel_ = (int)event.getZoomLevel();
     refreshItems();
     return true;
   }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/RouteOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/RouteOverlay.java
@@ -90,11 +90,11 @@ public class RouteOverlay extends Overlay implements PauseResumeListener, Route.
 
     final IGeoPoint centre = mapView.getMapCenter();
 
-    if (zoomLevel_ != mapView.getZoomLevel() ||
+    if (zoomLevel_ != (int)mapView.getZoomLevelDouble() ||
        highlight_ != Route.journey().activeSegment() ||
        !centre.equals(mapCentre_)) {
       ridePath_ = null;
-      zoomLevel_ = mapView.getProjection().getZoomLevel();
+      zoomLevel_ = (int)mapView.getProjection().getZoomLevel();
       highlight_ = Route.journey().activeSegment();
       mapCentre_ = centre;
     }

--- a/libraries/cyclestreets-view/src/main/java/org/mapsforge/map/android/MapsforgeOSMTileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/org/mapsforge/map/android/MapsforgeOSMTileSource.java
@@ -21,7 +21,6 @@ import org.mapsforge.map.rendertheme.XmlRenderTheme;
 import org.mapsforge.map.rendertheme.rule.RenderThemeFuture;
 import org.mapsforge.map.rendertheme.InternalRenderTheme;
 import org.osmdroid.tileprovider.ExpirableBitmapDrawable;
-import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.tilesource.BitmapTileSourceBase.LowMemoryException;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 
@@ -173,7 +172,7 @@ public class MapsforgeOSMTileSource implements ITileSource {
   @Override
   public Drawable getDrawable(InputStream arg0) throws LowMemoryException { return null; }
   @Override
-  public String getTileRelativeFilenameString(final MapTile tile) { return null; }
+  public String getTileRelativeFilenameString(final long pMapTileIndex) { return null; }
 
   ///////////
   private static int lon2XTile(final double lon, final int zoom) {

--- a/libraries/cyclestreets-view/src/main/java/org/osmdroid/tileprovider/modules/CycleStreetsTileDownloader.java
+++ b/libraries/cyclestreets-view/src/main/java/org/osmdroid/tileprovider/modules/CycleStreetsTileDownloader.java
@@ -9,12 +9,12 @@ import net.cyclestreets.tiles.UpsizingTileSource;
 import net.cyclestreets.util.Logging;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.BitmapPool;
-import org.osmdroid.tileprovider.MapTile;
 import org.osmdroid.tileprovider.MapTileRequestState;
 import org.osmdroid.tileprovider.ReusableBitmapDrawable;
 import org.osmdroid.tileprovider.tilesource.BitmapTileSourceBase.LowMemoryException;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+import org.osmdroid.util.MapTileIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,14 +43,14 @@ import static org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConst
  */
 public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
   private interface IOnlineTileSource {
-    String getTileURLString(MapTile aTile);
+    String getTileURLString(long pMapTileIndex);
     Drawable getDrawable(InputStream aTileInputStream) throws LowMemoryException;
     ITileSource unwrap();
   }
   private static class OnlineTileSourceWrapper implements IOnlineTileSource {
     private OnlineTileSourceBase otsb_;
     OnlineTileSourceWrapper(OnlineTileSourceBase otsb) { otsb_ = otsb; }
-    public String getTileURLString(MapTile aTile) { return otsb_.getTileURLString(aTile); }
+    public String getTileURLString(long pMapTileIndex) { return otsb_.getTileURLString(pMapTileIndex); }
     public Drawable getDrawable(InputStream aTileInputStream) throws LowMemoryException {
       return otsb_.getDrawable(aTileInputStream);
     }
@@ -59,7 +59,7 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
   private static class UpsizingTileSourceWrapper implements IOnlineTileSource {
     private UpsizingTileSource uts_;
     UpsizingTileSourceWrapper(UpsizingTileSource uts) { uts_ = uts; }
-    public String getTileURLString(MapTile aTile) { return uts_.getTileURLString(aTile); }
+    public String getTileURLString(long pMapTileIndex) { return uts_.getTileURLString(pMapTileIndex); }
     public Drawable getDrawable(InputStream aTileInputStream) throws LowMemoryException {
       return uts_.getDrawable(aTileInputStream);
     }
@@ -161,7 +161,7 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
   }
 
   @Override
-  protected Runnable getTileLoader() {
+  public MapTileModuleProviderBase.TileLoader getTileLoader() {
     return new TileLoader();
   }
 
@@ -195,18 +195,16 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
   // ===========================================================
   protected class TileLoader extends MapTileModuleProviderBase.TileLoader {
     @Override
-    public Drawable loadTile(final MapTileRequestState aState) throws CantContinueException {
+    public Drawable loadTile(final long pMapTileIndex) throws CantContinueException {
       IOnlineTileSource tileSource = mTileSource.get();
       if (tileSource == null)
         return null;
-
-      final MapTile tile = aState.getMapTile();
 
       try {
         if (mNetworkAvailablityCheck != null && !mNetworkAvailablityCheck.getNetworkAvailable())
           return null;
 
-        final String tileURLString = tileSource.getTileURLString(tile);
+        final String tileURLString = tileSource.getTileURLString(pMapTileIndex);
         Log.d(TAG, "Want to fetch tile from url: " + tileURLString);
         if (TextUtils.isEmpty(tileURLString))
           return null;
@@ -218,13 +216,13 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
 
         // Check to see if we got success
         if (!response.isSuccessful()) {
-          logger.warn("Problem downloading MapTile: " + tile + " HTTP response: " + response.code());
+          logger.warn("Problem downloading MapTile: " + MapTileIndex.toString(pMapTileIndex) + " HTTP response: " + response.code());
           return null;
         }
 
         final byte[] data = response.body().bytes();
         if (data.length == 0) {
-          logger.warn("No content downloading MapTile: " + tile);
+          logger.warn("No content downloading MapTile: " + MapTileIndex.toString(pMapTileIndex));
           return null;
         }
 
@@ -232,7 +230,7 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
 
         // Save the data to the filesystem cache
         if (mFilesystemCache != null) {
-          mFilesystemCache.saveFile(tileSource.unwrap(), tile, byteStream);
+          mFilesystemCache.saveFile(tileSource.unwrap(), pMapTileIndex, byteStream, 0L);
           byteStream.reset();
         }
         final Drawable result = tileSource.getDrawable(byteStream);
@@ -240,18 +238,18 @@ public class CycleStreetsTileDownloader extends MapTileModuleProviderBase {
         return result;
       } catch (final UnknownHostException e) {
         // no network connection so empty the queue
-        logger.warn("UnknownHostException downloading MapTile: " + tile + " : " + e);
+        logger.warn("UnknownHostException downloading MapTile: " + MapTileIndex.toString(pMapTileIndex) + " : " + e);
         throw new CantContinueException(e);
       } catch (final LowMemoryException e) {
         // low memory so empty the queue
-        logger.warn("LowMemoryException downloading MapTile: " + tile + " : " + e);
+        logger.warn("LowMemoryException downloading MapTile: " + MapTileIndex.toString(pMapTileIndex) + " : " + e);
         throw new CantContinueException(e);
       } catch (final FileNotFoundException e) {
-        logger.warn("Tile not found: " + tile + " : " + e);
+        logger.warn("Tile not found: " + MapTileIndex.toString(pMapTileIndex) + " : " + e);
       } catch (final IOException e) {
-        logger.warn("IOException downloading MapTile: " + tile + " : " + e);
+        logger.warn("IOException downloading MapTile: " + MapTileIndex.toString(pMapTileIndex) + " : " + e);
       } catch (final Throwable e) {
-        logger.error("Error downloading MapTile: " + tile, e);
+        logger.error("Error downloading MapTile: " + MapTileIndex.toString(pMapTileIndex), e);
       }
 
       return null;


### PR DESCRIPTION
This PR:
-  upgrades `osmdroid` to the current latest (from `5.6.5` to `6.0.3`)
-  handles the necessary API changes
-  in addition, limits the north/south (latitude) scrollability of the map to the range [-80, 80] degrees.  (This ability was introduced in version `6.0.0` and is the main reason I did the upgrade at this point.)

To give a little more context on the last point:
-  previously, you could keep scrolling north/south beyond what's logical (e.g. go beyond Antarctica to Greenland) as many times as you like
-  I initially limited the scrollability to the absolute poles (as per https://github.com/osmdroid/osmdroid/blob/master/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java#L741-L759)
-  There was still a lot of "blank space" and I can't believe there's any meaningful routing to be done at extreme latitudes, so I dropped the limits to +80 / -80 degrees.

See the screenshots below for more.

## Before
<img width="337" alt="screen shot 2018-07-25 at 11 32 10" src="https://user-images.githubusercontent.com/6017680/43195951-6ae3773a-8ffe-11e8-90db-839099bf6275.png">

## With scrolling limited to 90 degrees north or south
![screen shot 2018-07-25 at 09 48 20](https://user-images.githubusercontent.com/6017680/43191727-acf1f134-8ff3-11e8-86bf-034b7bbc3efa.png)
![screen shot 2018-07-25 at 09 48 32](https://user-images.githubusercontent.com/6017680/43191726-acc28930-8ff3-11e8-822f-d167b4382400.png)

## With scrolling limited to 80 degrees north or south
<img width="344" alt="screen shot 2018-07-25 at 10 08 27" src="https://user-images.githubusercontent.com/6017680/43191675-8dd20b86-8ff3-11e8-8a86-2d612da7c02f.png">
<img width="344" alt="screen shot 2018-07-25 at 10 08 05" src="https://user-images.githubusercontent.com/6017680/43191677-8e1d75f8-8ff3-11e8-8d33-86de5ac6c493.png">
