### PR TITLE
Fix route finding failures for single-segment routes

### DIFF
--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     exclude group: 'stax', module: 'stax'
   }
   implementation 'com.squareup.retrofit2:converter-jackson:2.4.0'
+  implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
   implementation 'de.grundid.opendatalab:geojson-jackson:1.8'
 
   // Jackson is already included transitively from multiple sources; we specify explicit versions

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/JourneyStringTransformer.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/JourneyStringTransformer.kt
@@ -36,7 +36,7 @@ private const val V1API_XML_JOLT_SPEC = """[{
         "*": {
           "type": {
             "route": { "@(2)": "route" },
-            "segment": { "@(2)": "segments" }
+            "segment": { "@(2)": "segments[]" }
           }
         }
       }
@@ -56,7 +56,7 @@ private const val V1API_JSON_JOLT_SPEC = """[{
         "\\@attributes": {
           "type": {
             "route": { "@(2)": "route" },
-            "segment": { "@(2)": "segments" }
+            "segment": { "@(2)": "segments[]" }
           }
         }
       }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
@@ -63,7 +63,7 @@ public class RetrofitApiClient {
     Cache cache = new Cache(new File(context.getCacheDir(), CACHE_DIR_NAME), CACHE_MAX_SIZE_BYTES);
     OkHttpClient client = new OkHttpClient.Builder()
             .addInterceptor(new ApiKeyInterceptor(builder.apiKey))
-            .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+            .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE))
             .addNetworkInterceptor(new RewriteCacheControlInterceptor())
             .cache(cache)
             .build();

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
@@ -38,6 +38,7 @@ import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
+import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -62,6 +63,7 @@ public class RetrofitApiClient {
     Cache cache = new Cache(new File(context.getCacheDir(), CACHE_DIR_NAME), CACHE_MAX_SIZE_BYTES);
     OkHttpClient client = new OkHttpClient.Builder()
             .addInterceptor(new ApiKeyInterceptor(builder.apiKey))
+            .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
             .addNetworkInterceptor(new RewriteCacheControlInterceptor())
             .cache(cache)
             .build();

--- a/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/JourneyStringTransformerTest.java
+++ b/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/JourneyStringTransformerTest.java
@@ -19,12 +19,14 @@ import java.io.IOException;
 public class JourneyStringTransformerTest {
 
     private static String expectedJson;
+    private static String expectedSingleSegmentJson;
 
     @BeforeClass
     public static void setup() throws IOException {
         // We want to validate that transforming from either V1 API (XML or JSON) results in the
         // same domain JSON.
         expectedJson = TestUtils.fromResourceFile("journey-domain.json");
+        expectedSingleSegmentJson = TestUtils.fromResourceFile("journey-single-segment-domain.json");
     }
 
     @Test
@@ -39,6 +41,20 @@ public class JourneyStringTransformerTest {
         String inputJson = TestUtils.fromResourceFile("__files/journey-v1api.json");
         String outputJson = JourneyStringTransformerKt.fromV1ApiJson(inputJson);
         JSONAssert.assertEquals(expectedJson, outputJson, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void singleSegmentXmlTransformation() throws IOException, JSONException {
+        String inputJson = TestUtils.fromResourceFile("__files/journey-v1api-single-segment.xml");
+        String outputJson = JourneyStringTransformerKt.fromV1ApiXml(inputJson);
+        JSONAssert.assertEquals(expectedSingleSegmentJson, outputJson, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void singleSegmentJsonTransformation() throws IOException, JSONException {
+        String inputJson = TestUtils.fromResourceFile("__files/journey-v1api-single-segment.json");
+        String outputJson = JourneyStringTransformerKt.fromV1ApiJson(inputJson);
+        JSONAssert.assertEquals(expectedSingleSegmentJson, outputJson, JSONCompareMode.STRICT);
     }
 
     /**

--- a/libraries/cyclestreets-core/src/test/resources/__files/journey-v1api-single-segment.json
+++ b/libraries/cyclestreets-core/src/test/resources/__files/journey-v1api-single-segment.json
@@ -1,0 +1,82 @@
+{
+  "marker": [
+    {
+      "@attributes": {
+        "start": "Thoday Street",
+        "finish": "Thoday Street",
+        "startBearing": "0",
+        "startSpeed": "0",
+        "start_longitude": "0.14771",
+        "start_latitude": "52.20004",
+        "finish_longitude": "0.14682",
+        "finish_latitude": "52.19870",
+        "crow_fly_distance": "161",
+        "event": "depart",
+        "whence": "1535615311",
+        "speed": "20",
+        "itinerary": "63123653",
+        "clientRouteId": "0",
+        "plan": "balanced",
+        "note": "",
+        "length": "161",
+        "time": "45",
+        "busynance": "218",
+        "quietness": "74",
+        "signalledJunctions": "0",
+        "signalledCrossings": "0",
+        "west": "0.14682",
+        "south": "52.19870",
+        "east": "0.14771",
+        "north": "52.20004",
+        "name": "Thoday Street to Thoday Street",
+        "walk": "0",
+        "leaving": "2018-08-30 08:48:31",
+        "arriving": "2018-08-30 08:49:16",
+        "coordinates": "0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870",
+        "elevations": "14,15,15,15,15,16",
+        "distances": "44,62,9,5,41",
+        "grammesCO2saved": "30",
+        "calories": "4",
+        "edition": "routing180820",
+        "type": "route"
+      }
+    },
+    {
+      "@attributes": {
+        "name": "Thoday Street",
+        "legNumber": "1",
+        "distance": "161",
+        "time": "45",
+        "busynance": "218",
+        "flow": "with",
+        "walk": "0",
+        "signalledJunctions": "0",
+        "signalledCrossings": "0",
+        "turn": "",
+        "startBearing": "201",
+        "color": "#000000",
+        "points": "0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870",
+        "distances": "0,44,62,9,5,41",
+        "elevations": "14,15,15,15,15,16",
+        "provisionName": "Residential street",
+        "type": "segment"
+      }
+    }
+  ],
+  "waypoint": [
+    {
+      "@attributes": {
+        "sequenceId": "1",
+        "longitude": "0.14771",
+        "latitude": "52.20004"
+      }
+    },
+    {
+      "@attributes": {
+        "sequenceId": "2",
+        "longitude": "0.14682",
+        "latitude": "52.19870"
+      }
+    }
+  ]
+}

--- a/libraries/cyclestreets-core/src/test/resources/__files/journey-v1api-single-segment.xml
+++ b/libraries/cyclestreets-core/src/test/resources/__files/journey-v1api-single-segment.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<markers xmlns:cs="https://www.cyclestreets.net/schema/xml/">
+  <marker start="Thoday Street" finish="Thoday Street" startBearing="0" startSpeed="0" start_longitude="0.14771" start_latitude="52.20004" finish_longitude="0.14682" finish_latitude="52.19870" crow_fly_distance="161" event="depart" whence="1535615311" speed="20" itinerary="63123653" clientRouteId="0" plan="balanced" note="" length="161" time="45" busynance="218" quietness="74" signalledJunctions="0" signalledCrossings="0" west="0.14682" south="52.19870" east="0.14771" north="52.20004" name="Thoday Street to Thoday Street" walk="0" leaving="2018-08-30 08:48:31" arriving="2018-08-30 08:49:16" coordinates="0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870" elevations="14,15,15,15,15,16" distances="44,62,9,5,41" grammesCO2saved="30" calories="4" edition="routing180820" type="route"/>
+  <waypoint sequenceId="1" longitude="0.14771" latitude="52.20004"/>
+  <waypoint sequenceId="2" longitude="0.14682" latitude="52.19870"/>
+  <marker name="Thoday Street" legNumber="1" distance="161" time="45" busynance="218" flow="with" walk="0" signalledJunctions="0" signalledCrossings="0" turn="" startBearing="201" color="#000000" points="0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870" distances="0,44,62,9,5,41" elevations="14,15,15,15,15,16" provisionName="Residential street" type="segment"/>
+</markers>

--- a/libraries/cyclestreets-core/src/test/resources/journey-single-segment-domain.json
+++ b/libraries/cyclestreets-core/src/test/resources/journey-single-segment-domain.json
@@ -1,0 +1,74 @@
+{
+  "waypoints": [
+    {
+      "sequenceId": "1",
+      "longitude": "0.14771",
+      "latitude": "52.20004"
+    },
+    {
+      "sequenceId": "2",
+      "longitude": "0.14682",
+      "latitude": "52.19870"
+    }
+  ],
+  "route": {
+    "start": "Thoday Street",
+    "finish": "Thoday Street",
+    "startBearing": "0",
+    "startSpeed": "0",
+    "start_longitude": "0.14771",
+    "start_latitude": "52.20004",
+    "finish_longitude": "0.14682",
+    "finish_latitude": "52.19870",
+    "crow_fly_distance": "161",
+    "event": "depart",
+    "whence": "1535615311",
+    "speed": "20",
+    "itinerary": "63123653",
+    "clientRouteId": "0",
+    "plan": "balanced",
+    "note": "",
+    "length": "161",
+    "time": "45",
+    "busynance": "218",
+    "quietness": "74",
+    "signalledJunctions": "0",
+    "signalledCrossings": "0",
+    "west": "0.14682",
+    "south": "52.19870",
+    "east": "0.14771",
+    "north": "52.20004",
+    "name": "Thoday Street to Thoday Street",
+    "walk": "0",
+    "leaving": "2018-08-30 08:48:31",
+    "arriving": "2018-08-30 08:49:16",
+    "coordinates": "0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870",
+    "elevations": "14,15,15,15,15,16",
+    "distances": "44,62,9,5,41",
+    "grammesCO2saved": "30",
+    "calories": "4",
+    "edition": "routing180820",
+    "type": "route"
+  },
+  "segments": [
+    {
+      "name": "Thoday Street",
+      "legNumber": "1",
+      "distance": "161",
+      "time": "45",
+      "busynance": "218",
+      "flow": "with",
+      "walk": "0",
+      "signalledJunctions": "0",
+      "signalledCrossings": "0",
+      "turn": "",
+      "startBearing": "201",
+      "color": "#000000",
+      "points": "0.14771,52.20004 0.14748,52.19967 0.14714,52.19915 0.14707,52.19908 0.14704,52.19904 0.14682,52.19870",
+      "distances": "0,44,62,9,5,41",
+      "elevations": "14,15,15,15,15,16",
+      "provisionName": "Residential street",
+      "type": "segment"
+    }
+  ]
+}

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Journey.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Journey.java
@@ -134,7 +134,7 @@ public class Journey
       try {
         jdo = objectMapper.readValue(domainJson, JourneyDomainObject.class);
       } catch (IOException e) {
-        throw new RuntimeException("Coding error - unable to parse domain JSON");
+        throw new RuntimeException("Coding error - unable to parse domain JSON", e);
       }
 
       populateWaypoints(jdo);

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 import android.widget.Toast;
 
 import net.cyclestreets.CycleStreetsPreferences;
+import net.cyclestreets.util.Logging;
 import net.cyclestreets.view.R;
 import net.cyclestreets.content.RouteData;
 import net.cyclestreets.content.RouteDatabase;
@@ -15,6 +17,8 @@ import net.cyclestreets.content.RouteSummary;
 
 public class Route
 {
+  private static final String TAG = Logging.getTag(Route.class);
+
   public interface Listener {
     void onNewJourney(final Journey journey, final Waypoints waypoints);
     void onResetJourney();
@@ -142,6 +146,7 @@ public class Route
       return true;
     }
     catch (Exception e) {
+      Log.w(TAG, "Route finding failed", e);
       Toast.makeText(context_, R.string.route_finding_failed, Toast.LENGTH_LONG).show();
     }
     return false;


### PR DESCRIPTION
Closes #298.

This PR also
-  improves the logging we do around route finding failures
-  introduces OkHttp's `HttpLoggingInterceptor`, but leaves it disabled by default since at the moment there doesn't seem to be a way to stop it from logging the API key, which I'd rather not do (see https://github.com/square/okhttp/issues/4244).