### PR TITLE
Fix recursion bug; add a logging interceptor

### DIFF
--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     exclude group: 'stax', module: 'stax'
   }
   implementation 'com.squareup.retrofit2:converter-jackson:2.4.0'
-  implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
   implementation 'de.grundid.opendatalab:geojson-jackson:1.8'
 
   // Jackson is already included transitively from multiple sources; we specify explicit versions

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/ApiClient.kt
@@ -113,16 +113,16 @@ object ApiClient : CycleStreetsApi {
         return delegate.register(username, password, name, email)
     }
     override fun getPOICategories(iconSize: Int): POICategories {
-        return getPOICategories(iconSize)
+        return delegate.getPOICategories(iconSize)
     }
     override fun getPOIs(key: String, lonE: Double, lonW: Double, latN: Double, latS: Double): List<POI> {
-        return getPOIs(key, lonE, lonW, latN, latS)
+        return delegate.getPOIs(key, lonE, lonW, latN, latS)
     }
     override fun getPOIs(key: String, lon: Double, lat: Double, radius: Int): List<POI> {
-        return getPOIs(key, lon, lat, radius)
+        return delegate.getPOIs(key, lon, lat, radius)
     }
     override fun getBlogEntries(): Blog {
-        return getBlogEntries()
+        return delegate.getBlogEntries()
     }
 
 }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/HttpLoggingInterceptor.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/HttpLoggingInterceptor.kt
@@ -1,0 +1,27 @@
+package net.cyclestreets.api.client
+
+import android.util.Log
+import net.cyclestreets.util.Logging
+import java.io.IOException
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.internal.http.StatusLine
+
+private val TAG = Logging.getTag(HttpLoggingInterceptor::class.java)
+private val API_KEY_REGEX = "key=\\w+".toRegex()
+
+class HttpLoggingInterceptor : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val url = request.url().toString().replace(API_KEY_REGEX, "key=redacted")
+
+        Log.d(TAG, "Sending request $url with headers ${request.headers()}")
+        val response = chain.proceed(request)
+
+        Log.d(TAG, "Received ${StatusLine.get(response)} response for $url")
+        return response
+    }
+}

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/HttpLoggingInterceptor.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/HttpLoggingInterceptor.kt
@@ -18,10 +18,10 @@ class HttpLoggingInterceptor : Interceptor {
         val request = chain.request()
         val url = request.url().toString().replace(API_KEY_REGEX, "key=redacted")
 
-        Log.d(TAG, "Sending request $url with headers ${request.headers()}")
+        Log.d(TAG, "Sending request: $url with headers: ${request.headers()}")
         val response = chain.proceed(request)
 
-        Log.d(TAG, "Received ${StatusLine.get(response)} response for $url")
+        Log.d(TAG, "Received ${StatusLine.get(response)} response for: $url")
         return response
     }
 }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
@@ -38,7 +38,6 @@ import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
-import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
@@ -63,7 +62,7 @@ public class RetrofitApiClient {
     Cache cache = new Cache(new File(context.getCacheDir(), CACHE_DIR_NAME), CACHE_MAX_SIZE_BYTES);
     OkHttpClient client = new OkHttpClient.Builder()
             .addInterceptor(new ApiKeyInterceptor(builder.apiKey))
-            .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE))
+            .addInterceptor(new HttpLoggingInterceptor())
             .addNetworkInterceptor(new RewriteCacheControlInterceptor())
             .cache(cache)
             .build();

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Logging.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/util/Logging.java
@@ -3,7 +3,7 @@ package net.cyclestreets.util;
 public class Logging {
 
   public static String getTag(Class clazz) {
-    return clazz.getCanonicalName().replace("net.cyclestreets", "");
+    return clazz.getCanonicalName().replace("net.cyclestreets.", "");
   }
 
 }


### PR DESCRIPTION
Adding in a custom logging interceptor so we don't log the API key.

Also fixing a recursion bug accidentally introduced by a previous PR - my bad.