### PR TITLE
Explanatory messages for Live Ride screen lock button

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LockScreenOnOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LockScreenOnOverlay.java
@@ -1,5 +1,6 @@
 package net.cyclestreets.views.overlay;
 
+import android.widget.Toast;
 import net.cyclestreets.util.Theme;
 import net.cyclestreets.view.R;
 import net.cyclestreets.views.CycleMapView;
@@ -27,18 +28,18 @@ public class LockScreenOnOverlay extends Overlay implements PauseResumeListener 
   private final CycleMapView mapView;
 
   private final FloatingActionButton screenLockButton;
-  private final Drawable on;
-  private final Drawable off;
+  private final Drawable onIcon;
+  private final Drawable offIcon;
 
   public LockScreenOnOverlay(final Context context, final CycleMapView mapView) {
     super();
     this.mapView = mapView;
 
-    on = new IconicsDrawable(context)
+    onIcon = new IconicsDrawable(context)
         .icon(GoogleMaterial.Icon.gmd_lock_open)
         .color(Theme.highlightColor(context))
         .sizeDp(24);
-    off = new IconicsDrawable(context)
+    offIcon = new IconicsDrawable(context)
         .icon(GoogleMaterial.Icon.gmd_lock_open)
         .color(Theme.lowlightColor(context))
         .sizeDp(24);
@@ -48,7 +49,7 @@ public class LockScreenOnOverlay extends Overlay implements PauseResumeListener 
     screenLockButton.setOnClickListener(view -> screenLockButtonTapped());
     mapView.addView(liverideButtonView);
 
-    setScreenLockState(mapView.getKeepScreenOn());
+    mapView.setKeepScreenOn(false);
   }
 
   private void screenLockButtonTapped() {
@@ -57,7 +58,9 @@ public class LockScreenOnOverlay extends Overlay implements PauseResumeListener 
 
   private void setScreenLockState(boolean state) {
     Log.d("LiveRide", "Setting keepScreenOn state to " + state);
-    screenLockButton.setImageDrawable(state ? on : off);
+    screenLockButton.setImageDrawable(state ? onIcon : offIcon);
+    int message = state ? R.string.liveride_keep_screen_on_enabled : R.string.liveride_keep_screen_on_disabled;
+    Toast.makeText(mapView.getContext(), message, Toast.LENGTH_LONG).show();
     mapView.setKeepScreenOn(state);
   }
 

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -115,6 +115,10 @@
   <string name="account_pending">You have already registered an account.  Please check your email for the verification email.</string>
   <string name="account_registration_is_free_long">Registration is free and registered users can add photos. To start the registration process please enter your details in the form below.</string>
 
+  <!-- LiveRide -->
+  <string name="liveride_keep_screen_on_enabled" translatable="false">Screen will remain on while LiveRide is running</string>
+  <string name="liveride_keep_screen_on_disabled" translatable="false">Screen will timeout as normal</string>
+
   <!-- Permission justifications -->
   <string name="perm_justification_format" translatable="false"><![CDATA[
     <p>In the next dialog, you will have the opportunity to grant a permission to this app.  We would like to use this permission in order to:</p>%1$s


### PR DESCRIPTION
Relates to discussions in #42 and #303.

This PR does not change the images that are used (since we have yet to come to an agreement around that) but it does add an explanatory message (slightly tweaked from @si-the-pie's original suggestions).  It also fixes the you-need-to-click-twice-the-first-time issue.

I hope this is sufficient for the 3.6 release.

@si-the-pie @mvl22 when you've discussed between yourselves and agreed what the icons should be for the subsequent 3.7 release, please raise a new issue accordingly (or just a PR - it should be pretty obvious what the trivial changes would be to adjust which icons are chosen).