### PR TITLE
Allow HTTPS intents for cycle.st URLs

### DIFF
--- a/cyclestreets.app/src/main/AndroidManifest.xml
+++ b/cyclestreets.app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
         <data android:scheme="http"
               android:host="cycle.st"
               android:pathPrefix="/j" />
+        <data android:scheme="https"
+              android:host="cycle.st"
+              android:pathPrefix="/j" />
         <data android:scheme="http"
               android:host="cyclestreets.net"
               android:pathPrefix="/journey/" />
@@ -44,6 +47,9 @@
               android:pathPrefix="/journey/" />
         <!-- Location URLs -->
         <data android:scheme="http"
+              android:host="cycle.st"
+              android:pathPrefix="/p" />
+        <data android:scheme="https"
               android:host="cycle.st"
               android:pathPrefix="/p" />
         <data android:scheme="http"

--- a/libraries/cyclestreets-fragments/src/test/java/net/cyclestreets/MainSupportTest.kt
+++ b/libraries/cyclestreets-fragments/src/test/java/net/cyclestreets/MainSupportTest.kt
@@ -30,7 +30,7 @@ class MainSupportTest {
 
     @Test
     fun mobileJourney() {
-        val launchIntent = determineLaunchIntent(Uri.parse("https://m.cyclestreets.net/journey/#57201887/balanced"))!!
+        val launchIntent = determineLaunchIntent(Uri.parse("http://m.cyclestreets.net/journey/#57201887/balanced"))!!
         assertThat(launchIntent.type).isEqualTo(JOURNEY)
         assertThat(launchIntent.id).isEqualTo(57201887)
     }
@@ -51,7 +51,7 @@ class MainSupportTest {
 
     @Test
     fun cycleStreetsNetLocation() {
-        val launchIntent = determineLaunchIntent(Uri.parse("http://cyclestreets.net/location/1234"))!!
+        val launchIntent = determineLaunchIntent(Uri.parse("http://www.cyclestreets.net/location/1234"))!!
         assertThat(launchIntent.type).isEqualTo(LOCATION)
         assertThat(launchIntent.id).isEqualTo(1234)
     }


### PR DESCRIPTION
Addresses @mvl22's post-merge comment https://github.com/cyclestreets/android/commit/f0441828cdef6d23d2436459e08f07d375103477#commitcomment-30390774 following PR #319

>Just to flag up that cycle.st is about to get HTTPS at last - for some reason this was accidentally missed when we shifted our infrastructure to HTTPS. So please do include this in the list of intents.