### PR TITLE
Shift map attribution right in LiveRide

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/LiveRideActivity.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/LiveRideActivity.kt
@@ -83,6 +83,7 @@ class LiveRideActivity : Activity(), ServiceConnection, LiveRideOverlay.Locator 
             overlayPushTop(LiveRideOverlay(this@LiveRideActivity, this@LiveRideActivity))
             lockOnLocation()
             hideLocationButton()
+            shiftAttributionRight()
         }
         RelativeLayout(this).apply {
             addView(map,

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -224,6 +224,7 @@ public class CycleMapView extends FrameLayout
   public void enableAndFollowLocation() { location_.enableAndFollowLocation(true); }
   public void lockOnLocation() { location_.lockOnLocation(); }
   public void hideLocationButton() { location_.hideButton(); }
+  public void shiftAttributionRight() { controllerOverlay_.setAttributionShiftedRight(); }
 
   ///////////////////////////////////////////////////////
   public void centreOn(final IGeoPoint place) {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
@@ -19,7 +19,6 @@ import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Rect;
-import android.util.Log;
 import android.view.ContextMenu;
 import android.view.GestureDetector;
 import android.view.Menu;
@@ -36,6 +35,7 @@ public class ControllerOverlay extends Overlay implements OnDoubleTapListener, O
   private final CycleMapView mapView_;
   private final Paint textBrush_;
   private List<Undoable> undoStack_;
+  private boolean attributionShiftedRight;
 
   public ControllerOverlay(final CycleMapView mapView) {
     super();
@@ -157,10 +157,15 @@ public class ControllerOverlay extends Overlay implements OnDoubleTapListener, O
 
   private void drawUnskewed(final Canvas canvas) {
     final Rect screen = canvas.getClipBounds();
+    final int x = attributionShiftedRight ? screen.centerX() * 3 / 2 : screen.centerX();
     canvas.drawText(mapView_.mapAttribution(),
-        screen.centerX(),
+        x,
         screen.bottom-(textBrush_.descent()+2),
         textBrush_);
+  }
+
+  public void setAttributionShiftedRight() {
+    this.attributionShiftedRight = true;
   }
 
   @Override


### PR DESCRIPTION
Closes #296.

Attribution is still centred in the middle of the screen usually, but in LiveRide we move it to be centred three-quarters of the way across.  See screenshot below.

<img width="323" alt="screen shot 2018-09-07 at 13 09 15" src="https://user-images.githubusercontent.com/6017680/45218373-43182480-b29f-11e8-8e40-fa790aa23abc.png">