### PR TITLE
364: Fix back-into-settings weird overlay bug

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -21,6 +21,7 @@
   <ul>
     <li>LiveRide no longer restarts on wake, so the annoying torrent of instructions is gone.</li>
     <li>Waypoint icons in Android 10 no longer appear ridiculously small and in the wrong place.</li>
+    <li>Navigating back after having previously used the Settings screen no longer results in a weird transparent menu overlay.</li>
     <li>Extra start waypoint added when replanning the journey does not persist, so multiple replans are dealt with more logically.</li>
     <li>A number of crash scenarios fixed.</li>
     <li>LiveRide now makes itself a foreground service, which fixes some scenarios where it previously wouldn't work (e.g. low available memory)</li>

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
@@ -62,8 +62,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
         fragmentManager!!.beginTransaction().let { ft ->
             ft.replace(id, settingsSubScreen)
-            Log.w(TAG, "Adding settings fragment ${preferenceScreen.key} to back stack")
-            ft.addToBackStack("settings-${preferenceScreen.key}").commit()
+            Log.d(TAG, "Adding settings fragment ${preferenceScreen.key} to back stack on top of ${fragmentManager!!.backStackEntryCount} existing entries")
+            ft.addToBackStack("Settings-${preferenceScreen.key}").commit()
         }
     }
 

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
@@ -38,8 +38,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     override fun onCreatePreferences(savedInstance: Bundle?, rootKey: String?) {
         if (arguments != null) {
-            Log.d(TAG, "Creating preferences subscreen with key $rootKey")
             val key = arguments!!.getString(PREFERENCE_SCREEN_ARG)
+            Log.d(TAG, "Creating preferences subscreen with key $key")
             setPreferencesFromResource(R.xml.prefs, key)
         } else {
             Log.d(TAG, "Creating root preferences page")
@@ -60,11 +60,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         this.enterTransition = Fade()
         this.exitTransition = Fade()
 
-        fragmentManager!!
-            .beginTransaction()
-            .replace(id, settingsSubScreen)
-            .addToBackStack(null)
-            .commit()
+        fragmentManager!!.beginTransaction().let { ft ->
+            ft.replace(id, settingsSubScreen)
+            Log.w(TAG, "Adding settings fragment ${preferenceScreen.key} to back stack")
+            ft.addToBackStack("settings-${preferenceScreen.key}").commit()
+        }
     }
 
     private fun setupMapStyles() {

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
@@ -60,10 +60,12 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         this.enterTransition = Fade()
         this.exitTransition = Fade()
 
-        fragmentManager!!.beginTransaction().let { ft ->
+        val fm = fragmentManager!!
+        fm.beginTransaction().let { ft ->
             ft.replace(id, settingsSubScreen)
-            Log.d(TAG, "Adding settings fragment ${preferenceScreen.key} to back stack on top of ${fragmentManager!!.backStackEntryCount} existing entries")
-            ft.addToBackStack("Settings-${preferenceScreen.key}").commit()
+            Log.d(TAG, "Adding settings fragment ${preferenceScreen.key} to back stack on top of ${fm.backStackEntryCount} existing entries")
+            ft.addToBackStack("Settings-${preferenceScreen.key}")
+              .commit()
         }
     }
 


### PR DESCRIPTION
Closes #364.

We still want to be able to use "back" while _within_ the Settings menu.  The approach I've taken is: when the user navigates out of the Settings menu (which, to my knowledge, can only be done via the main nav), any back-stack entries relating to the Settings menu are dropped.

I've tested fairly thoroughly on the emulator and it seems to do the right thing.

@jezhiggins, would you please review?