### PR TITLE
Rework Back button behaviour

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -15,7 +15,7 @@
     <li>Modernisation of some icons, using vector graphics for better resolution and smaller install size.</li>
     <li>LiveRide now requests audio focus which should improve the experience e.g. when also playing music.</li>
     <li>Target streets are now described as part of instructions - e.g. "Get ready to turn right" becomes "Get ready to turn right onto [street name]".</li>
-    <li>Pressing "back" now takes you back to your previous view, so you don't accidentally minimise the app so often.</li>
+    <li>Revised Back button behaviour.</li>
   </ul>
   <strong>Bug fixes:</strong>
   <ul>

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
@@ -27,6 +27,7 @@ import android.support.design.widget.NavigationView.OnNavigationItemSelectedList
 import android.support.transition.Fade
 import android.support.v4.app.FragmentManager.OnBackStackChangedListener
 import net.cyclestreets.addphoto.AddPhotoFragment
+import net.cyclestreets.api.JourneyPlanner
 import net.cyclestreets.iconics.IconicsHelper.materialIcons
 import net.cyclestreets.itinerary.ItineraryAndElevationFragment
 
@@ -118,7 +119,6 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
         // Swap UI fragments based on the selection
         this.supportFragmentManager.beginTransaction().let { ft ->
             ft.replace(R.id.content_frame, instantiateFragmentFor(menuItem))
-            ft.addToBackStack(null)
             ft.commit()
         }
 
@@ -170,10 +170,13 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
             return
         }
 
-
         visibleFragment()?.let {
             if (it is Undoable && it.onBackPressed())
                 return
+            if (it !is RouteMapFragment) {
+                showPage(R.id.nav_journey_planner)
+                return
+            }
         }
 
         super.onBackPressed()

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
@@ -62,7 +62,7 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
     )
 
     // If you're in one of these fragments at pause, then you'll be returned to it on resume.
-    private val resumableFragments = setOf(R.id.nav_journey_planner, R.id.nav_photomap, R.id.nav_addphoto)
+    private val resumableFragments = setOf(R.id.nav_journey_planner, R.id.nav_photomap, R.id.nav_addphoto, R.id.nav_settings)
 
     override fun attachBaseContext(newBase: Context) {
         // Allows the use of Material icon library, see https://github.com/mikepenz/Android-Iconics

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
@@ -39,7 +39,6 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
     private lateinit var navigationView: NavigationView
     private lateinit var toolbar: Toolbar
     private var selectedItem: Int = 0
-    private var currentFragment: Fragment? = null
 
     private val menuItemIdToFragment = object : SparseArray<Class<out Fragment>>() {
         init {
@@ -60,10 +59,6 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
         BlogFragment::class.java to R.id.nav_blog,
         SettingsFragment::class.java to R.id.nav_settings
     )
-
-    // The Journey Planner and Photomap are the 'heart' of the app.  Pressing 'back' on any other
-    // fragment should eventually return you to whichever of those you were using.
-    private val backOutableFragments = setOf(R.id.nav_itinerary, R.id.nav_addphoto, R.id.nav_blog, R.id.nav_settings)
 
     // If you're in one of these fragments at pause, then you'll be returned to it on resume.
     private val resumableFragments = setOf(R.id.nav_journey_planner, R.id.nav_photomap, R.id.nav_addphoto)
@@ -123,8 +118,7 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
         // Swap UI fragments based on the selection
         this.supportFragmentManager.beginTransaction().let { ft ->
             ft.replace(R.id.content_frame, instantiateFragmentFor(menuItem))
-            if (backOutableFragments.contains(menuItem.itemId))
-                ft.addToBackStack(null)
+            ft.addToBackStack(null)
             ft.commit()
         }
 
@@ -164,7 +158,6 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
             return fragmentClass.newInstance().apply {
                 enterTransition = Fade()
                 exitTransition = Fade()
-                currentFragment = this
             }
         }
         catch (e: InstantiationException) { throw RuntimeException(e) }
@@ -176,12 +169,21 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
             drawerLayout.closeDrawers()
             return
         }
-        currentFragment?.let {
+
+
+        visibleFragment()?.let {
             if (it is Undoable && it.onBackPressed())
                 return
         }
 
         super.onBackPressed()
+    }
+
+    private fun visibleFragment(): Fragment? {
+        for (fragment in supportFragmentManager.fragments)
+            if (fragment?.isVisible() == true)
+                return fragment
+        return null
     }
 
     protected open fun onFirstRun() {}

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
@@ -17,7 +17,8 @@ import net.cyclestreets.util.MessageBox
 private val TAG = Logging.getTag(SettingsFragment::class.java)
 private const val PREFERENCE_SCREEN_ARG: String = "preferenceScreenArg"
 
-class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedPreferenceChangeListener {
+class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedPreferenceChangeListener, Undoable {
+    var undoable = false
 
     override fun onCreate(savedInstance: Bundle?) {
         super.onCreate(savedInstance)
@@ -41,30 +42,41 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             Log.d(TAG, "Creating preferences subscreen with key $rootKey")
             val key = arguments!!.getString(PREFERENCE_SCREEN_ARG)
             setPreferencesFromResource(R.xml.prefs, key)
+            undoable = true
+            this.enterTransition = Slide(Gravity.END)
+            this.exitTransition = Slide(Gravity.END)
         } else {
             Log.d(TAG, "Creating root preferences page")
             setPreferencesFromResource(R.xml.prefs, rootKey)
+            this.enterTransition = Fade()
+            this.exitTransition = Fade()
         }
     }
 
     override fun onNavigateToScreen(preferenceScreen: PreferenceScreen) {
-        // Allow instantiation of subscreens
-        val args = Bundle()
-        args.putString(PREFERENCE_SCREEN_ARG, preferenceScreen.key)
-        val settingsSubScreen = SettingsFragment()
-        settingsSubScreen.arguments = args
+        showScreen(preferenceScreen.key)
+    }
 
-        // Make the transitions into and back out of subscreens look nice
-        settingsSubScreen.enterTransition = Slide(Gravity.END)
-        settingsSubScreen.exitTransition = Fade()
-        this.enterTransition = Fade()
-        this.exitTransition = Fade()
+    override fun onBackPressed(): Boolean {
+        if (undoable)
+            showScreen()
+        return undoable
+    }
+
+    private fun showScreen(key: String? = null) {
+        val screen = SettingsFragment()
+
+        if (key != null) {
+            val args = Bundle()
+            args.putString(PREFERENCE_SCREEN_ARG, key)
+            screen.arguments = args
+        }
 
         fragmentManager!!
-            .beginTransaction()
-            .replace(id, settingsSubScreen)
-            .addToBackStack(null)
-            .commit()
+                .beginTransaction()
+                .replace(id, screen)
+                .commit()
+
     }
 
     private fun setupMapStyles() {


### PR DESCRIPTION
Making Back button behaviour more straightforward.
    
Rather than trying to maintain the backstack through all the navigation menu changes (which isn't like behaviour of eg gmail or twitter), aiming for
    
* if you're on the journey planner, back leaves the app
* if you're not on the journey planner, back should take you to the journey planner
* unless you're part way through adding a photo, in which case back takes you to the previous step
* or you're on a setting subscreen, in which case back return you to settings
* or you're on the journey planner and planning a route, in which case back removes the most recent waypoint wisp

Fixes #368, will hopefully also address #364.