### PR TITLE
295: Point Blog URL to cyclestreets.org/news

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Blog.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/Blog.java
@@ -8,7 +8,7 @@ public class Blog
   private static final Blog NULL_BLOG;
   static {
     NULL_BLOG = new Blog(new ArrayList<BlogEntry>() {{
-      add(new BlogEntry("ERROR", "http://www.cyclestreets.net/blog/", "Could not retrieve CycleStreets blog entries", ""));
+      add(new BlogEntry("ERROR", "http://www.cyclestreets.org/news/", "Could not retrieve CycleStreets blog entries", ""));
     }});
   }
   private List<BlogEntry> entries = new ArrayList<>();

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/BlogFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/BlogFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 
-private const val CYCLE_STREETS_BLOG_URL = "https://www.cyclestreets.net/blog/"
+private const val CYCLE_STREETS_BLOG_URL = "https://www.cyclestreets.org/news/"
 
 class BlogFragment : WebPageFragment(CYCLE_STREETS_BLOG_URL) {
 


### PR DESCRIPTION
Prevents the redirect, so we stay with the app.

Fixes #295, specifically https://github.com/cyclestreets/android/issues/295#issuecomment-616092298