### PR TITLE
Prepare release notes for launching version 3.7

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,11 @@
 ## Releasing - notes for project maintainers
 
-1.  Ensure that What's New (`whatsnew.html`, plus `whatsnew` and `whatsnew-beta`) is all up-to-date
+1.  Ensure that What's New (`whatsnew.html`, plus `beta.txt` and `production.txt`) is all up-to-date
 2.  Ensure that the latest code built successfully on Travis and was published to the Beta track
-3.  Tag the latest commit - convention is e.g. RELEASE_3_6 for version 3.6
+3.  Tag the latest commit - convention is e.g. RELEASE_3_7 for version 3.7
 4.  In the Google Play developer console, promote the beta build to production
 5.  Run `./gradlew publishListingRelease` to update the Play store listings
 
 ### Post-release
 1.  Bump `versionName` in version.properties to the next release candidate
-2.  Clear the contents of `whatsnew-beta`; add a new section in `whatsnew.html` for the next round of development.
+2.  Clear the contents of `beta.txt`; add a new section in `whatsnew.html` for the next round of development.

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
@@ -1,12 +1,10 @@
-Closely-consecutive instructions (e.g. turn left, turn right) are now joined together to make live directions clearer.
-More waypoints - up to 30.
-Significant permissions now requested only when needed.
-Added a number of partial language translations.
-Elevation view improved.
-POI bubbles now show phone and opening hours, where available.
-Higher zoom levels now show more detail.
-Extensive design modernisation.
+Handle CycleStreets photomap location URLs.
+Waypoints shown during LiveRide.
+Dates included on photo display dialog.
+Active segment now highlighted on the elevation graph.
+Modernisation of some icons.
+LiveRide now requests audio focus over e.g. music.
+"Get ready to turn right" becomes "Get ready to turn right onto [street name]".
+Revised Back button behaviour.
 
 Numerous bug fixes.
-
-Deprecation: Pebble is no longer supported.


### PR DESCRIPTION
In my view we're in a good state to get 3.7 out the door.  Once this is approved and merged, I'll perform the remaining steps to get this done.