### PR TITLE
Fix NumberFormatException in Route.restoreWaypoints

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
@@ -195,7 +195,7 @@ object Route {
 
     private fun restoreWaypoints() {
         val stash = prefs().getString(waypointsInProgressPref, "")
-        if (stash.isNotEmpty()) {
+        if (stash != null && stash.isNotEmpty()) {
             waypoints_ = Waypoints(RouteDatabase.deserializeWaypoints(stash))
         }
     }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
@@ -194,9 +194,9 @@ object Route {
     }
 
     private fun restoreWaypoints() {
-        val stash = prefs().getString(waypointsInProgressPref, null)
-        stash?.let {
-            waypoints_ = Waypoints(RouteDatabase.deserializeWaypoints(it))
+        val stash = prefs().getString(waypointsInProgressPref, "")
+        if (stash.isNotEmpty()) {
+            waypoints_ = Waypoints(RouteDatabase.deserializeWaypoints(stash))
         }
     }
 


### PR DESCRIPTION
It's possible that the stashed waypoints string might be empty, rather
that null. In this case, attempting to restore waypoints at app start
will throw a number format exception and the app will crash.

This patch corrects that.