### PR TITLE
Fix pinch-zoom in LiveRide

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -14,6 +14,7 @@
 <strong>Bug fixes:</strong>
 <ul>
   <li>Directional location marker now visible again</li>
+  <li>Fixes pinch-zoom in LiveRide</li>
 </ul>
 
 <h3>Release 3.7.1</h3>

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,3 +1,4 @@
 Bug fixes:
 
 Directional location marker now visible again
+Fixes pinch-zoom in LiveRide

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
@@ -30,7 +30,6 @@ class LocationOverlay(private val mapView: CycleMapView) :
     private val button: FloatingActionButton
     private val onColor: Int = Theme.lowlightColor(mapView.context)
     private val followColor: Int = Theme.highlightColor(mapView.context) or -0x1000000
-    private var lockedOn: Boolean = false
 
     private class UseEverythingLocationProvider(context: Context) : GpsMyLocationProvider(context) {
         init {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
@@ -90,20 +90,23 @@ class LocationOverlay(private val mapView: CycleMapView) :
     }
 
     fun lockOnLocation() {
-        lockedOn = true
+        setEnableAutoStop(false)
     }
 
     fun hideButton() {
         button.visibility = View.INVISIBLE
     }
-
     override fun onTouchEvent(event: MotionEvent, mapView: MapView?): Boolean {
-        val handled = super.onTouchEvent(event, mapView)
+        val isSingleFingerDrag = (event.action == MotionEvent.ACTION_MOVE)
+                && (event.pointerCount == 1)
 
-        if (lockedOn && isMyLocationEnabled && event.action == MotionEvent.ACTION_MOVE)
-            enableFollowLocation()
+        if (event.action == MotionEvent.ACTION_DOWN && enableAutoStop) {
+            disableFollowLocation()
+        } else if (isSingleFingerDrag && isFollowLocationEnabled) {
+            return true // prevent the pan
+        }
 
-        return handled
+        return false
     }
 
     ////////////////////////////////////////////

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LocationOverlay.kt
@@ -96,6 +96,10 @@ class LocationOverlay(private val mapView: CycleMapView) :
     fun hideButton() {
         button.visibility = View.INVISIBLE
     }
+
+    // Allows pinch-zoom while in LiveRide
+    // see https://github.com/cyclestreets/android/issues/384
+    // and https://github.com/osmdroid/osmdroid/issues/1578
     override fun onTouchEvent(event: MotionEvent, mapView: MapView?): Boolean {
         val isSingleFingerDrag = (event.action == MotionEvent.ACTION_MOVE)
                 && (event.pointerCount == 1)


### PR DESCRIPTION
When locked on location, ignore single-finger pan events. Allow
multitouch through, so the gesture detector can pick up pinch-zoom
properly.

You do get a little bit of panning during a pinch-zoom (and also
double-tap zoom), but the next location update will recentre the map.

Fixes #384.