### PR TITLE
393: fix pronounciation of metres and kilometres

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -6,8 +6,10 @@
   -->
 
 <h3>Release 3.8 (BETA)</h3>
+<strong>Features:</strong>
 <ul>
   <li>LiveRide map rotates with direction of travel. Just tap the compass icon to activate.</li>
+  <li>Distances in metres and kilometres are now read out properly in LiveRide.</li>
 </ul>
 
 <h3>Release 3.7.2</h3>

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,1 +1,2 @@
 LiveRide map rotates with direction of travel. Just tap the compass icon to activate.
+Distances in metres and kilometres are now read out properly in LiveRide.

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.kt
@@ -118,9 +118,4 @@ internal abstract class LiveRideState(protected val context: Context,
         tts?.speak(speechify(words), TextToSpeech.QUEUE_ADD, null, UUID.randomUUID().toString())
     }
 
-    private fun speechify(words: String): String {
-        return words
-                .replace("LiveRide", "Live Ride")
-                .replace(Arrivee.ARRIVEE, "arreev eh")
-    }
 }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
@@ -1,0 +1,21 @@
+package net.cyclestreets.liveride
+
+private val REGEX_METRES = "(\\d+)m".toRegex()
+private val REGEX_KILOMETRES = "(\\d+)km".toRegex()
+
+
+fun speechify(words: String): String {
+
+    var updatedWords = words
+            .replace("LiveRide", "Live Ride")
+            .replace(Arrivee.ARRIVEE, "arreev eh")
+
+    updatedWords = REGEX_KILOMETRES.replace(updatedWords) {
+        matchResult: MatchResult -> "${matchResult.groupValues[1]} kilometres"
+    }
+    updatedWords = REGEX_METRES.replace(updatedWords) {
+        matchResult: MatchResult -> "${matchResult.groupValues[1]} metres"
+    }
+
+    return updatedWords;
+}

--- a/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
+++ b/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
@@ -1,0 +1,33 @@
+package net.cyclestreets.liveride
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+
+class SpeechFixerTest {
+
+    @Test
+    fun testLiveRideAndArrivee() {
+        assertThat(speechify("LiveRide will take us efficiently to the Arrivée"))
+                .isEqualTo("Live Ride will take us efficiently to the arreev eh")
+    }
+
+    @Test
+    fun testSimpleMetres() {
+        assertThat(speechify("Straight on into lcn (unknown cycle network) continuation. Continue 5m"))
+                .isEqualTo("Straight on into lcn (unknown cycle network) continuation. Continue 5 metres")
+    }
+
+    @Test
+    fun testLotsOfMetresAndKilometres() {
+        assertThat(speechify("Continue 600m, then 300km, another 10m, and finally 42km"))
+                .isEqualTo("Continue 600 metres, then 300 kilometres, another 10 metres, and finally 42 kilometres")
+    }
+
+    @Test
+    fun testNonIntegerKilometres() {
+        assertThat(speechify("Continue 3.69km"))
+                .isEqualTo("Continue 3.69 kilometres")
+    }
+
+}


### PR DESCRIPTION
Towards issue #393.

(doesn't close it, because there's still some open discussion about how to handle road numbers).