### PR TITLE
393: Fix how 3/4-digit road numbers are pronounced in LiveRide

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -9,7 +9,7 @@
 <strong>Features:</strong>
 <ul>
   <li>LiveRide map rotates with direction of travel. Just tap the compass icon to activate.</li>
-  <li>Distances in metres and kilometres are now read out properly in LiveRide.</li>
+  <li>Metric distances and 3/4 digit road numbers are now read out properly in LiveRide.</li>
 </ul>
 
 <h3>Release 3.7.2</h3>

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,2 +1,2 @@
 LiveRide map rotates with direction of travel. Just tap the compass icon to activate.
-Distances in metres and kilometres are now read out properly in LiveRide.
+Metric distances and 3/4 digit road numbers are now read out properly in LiveRide.

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
@@ -3,20 +3,42 @@ package net.cyclestreets.liveride
 private val REGEX_METRES = "(\\d+)m".toRegex()
 private val REGEX_KILOMETRES = "(\\d+)km".toRegex()
 
-private val REGEX_THREE_DIGIT_TENS = "([a-zA-Z])(\\d)([1-9]0)(\\D|\$)".toRegex()         // e.g. A230
-private val REGEX_THREE_DIGIT_MIDDLE_ZERO= "([a-zA-Z])(\\d)0([1-9])(\\D|\$)".toRegex()   // e.g. A404
-private val REGEX_THREE_DIGIT_OTHER= "([a-zA-Z])(\\d)([1-9])([1-9])(\\D|\$)".toRegex()  // e.g. A467
+private val REGEX_METRIC_DISTANCES: Map<Regex, (MatchResult) -> String> = mapOf(
+    REGEX_METRES     to { m -> "${m.groupValues[1]} metres" },
+    REGEX_KILOMETRES to { m -> "${m.groupValues[1]} kilometres" }
+)
 
-private val REGEX_FOUR_DIGIT_HUNDREDS = "([a-zA-Z])(\\d[1-9])00(\\D|\$)".toRegex()               // e.g. B1200
-private val REGEX_FOUR_DIGIT_TENS_AND_TENS = "([a-zA-Z])(\\d0)([1-9]0)(\\D|\$)".toRegex()        // e.g. A4030
-private val REGEX_FOUR_DIGIT_DIGITS_AND_TENS = "([a-zA-Z])(\\d[1-9])([1-9]0)(\\D|\$)".toRegex()  // e.g. A4130
-private val REGEX_FOUR_DIGIT_TENS_AND_DIGITS = "([a-zA-Z])(\\d0)([1-9][1-9])(\\D|\$)".toRegex()  // e.g. A4032
-private val REGEX_FOUR_DIGIT_MIDDLE_ZEROES = "([a-zA-Z])(\\d)00([1-9])(\\D|\$)".toRegex()        // e.g. B5001
-private val REGEX_FOUR_DIGIT_TREBLE_AT_START = "([a-zA-Z])(\\d)\\2\\2(\\d)(\\D|\$)".toRegex()    // e.g. B1113
-private val REGEX_FOUR_DIGIT_TREBLE_AT_END = "([a-zA-Z])(\\d)([1-9])\\3\\3(\\D|\$)".toRegex()    // e.g. A2111
-private val REGEX_FOUR_DIGIT_THIRD_DIGIT_0 = "([a-zA-Z])(\\d)([1-9])0([1-9])(\\D|\$)".toRegex()  // e.g. A2103
-private val REGEX_FOUR_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])([1-9])(\\D|\$)".toRegex()    // e.g. A4123
+private val REGEX_3_DIGIT_TENS = "([a-zA-Z])(\\d)([1-9]0)(\\D|\$)".toRegex()         // e.g. A230
+private val REGEX_3_DIGIT_MIDDLE_ZERO = "([a-zA-Z])(\\d)0([1-9])(\\D|\$)".toRegex()  // e.g. A404
+private val REGEX_3_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])(\\D|\$)".toRegex()  // e.g. A467
 
+private val REGEX_3_DIGIT_ROADS: Map<Regex, (MatchResult) -> String> = mapOf(
+    REGEX_3_DIGIT_TENS        to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_3_DIGIT_MIDDLE_ZERO to { m -> "${m.groupValues[1]}${m.groupValues[2]}-oh ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_3_DIGIT_OTHER       to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]}${m.groupValues[5]}" }
+)
+
+private val REGEX_4_DIGIT_HUNDREDS = "([a-zA-Z])(\\d[1-9])00(\\D|\$)".toRegex()               // e.g. B1200
+private val REGEX_4_DIGIT_TENS_AND_TENS = "([a-zA-Z])(\\d0)([1-9]0)(\\D|\$)".toRegex()        // e.g. A4030
+private val REGEX_4_DIGIT_DIGITS_AND_TENS = "([a-zA-Z])(\\d[1-9])([1-9]0)(\\D|\$)".toRegex()  // e.g. A4130
+private val REGEX_4_DIGIT_TENS_AND_DIGITS = "([a-zA-Z])(\\d0)([1-9][1-9])(\\D|\$)".toRegex()  // e.g. A4032
+private val REGEX_4_DIGIT_MIDDLE_ZEROES = "([a-zA-Z])(\\d)00([1-9])(\\D|\$)".toRegex()        // e.g. B5001
+private val REGEX_4_DIGIT_TREBLE_AT_START = "([a-zA-Z])(\\d)\\2\\2(\\d)(\\D|\$)".toRegex()    // e.g. B1113
+private val REGEX_4_DIGIT_TREBLE_AT_END = "([a-zA-Z])(\\d)([1-9])\\3\\3(\\D|\$)".toRegex()    // e.g. A2111
+private val REGEX_4_DIGIT_THIRD_DIGIT_0 = "([a-zA-Z])(\\d)([1-9])0([1-9])(\\D|\$)".toRegex()  // e.g. A2103
+private val REGEX_4_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])([1-9])(\\D|\$)".toRegex()    // e.g. A4123
+
+private val REGEX_4_DIGIT_ROADS: Map<Regex, (MatchResult) -> String> = mapOf(
+    REGEX_4_DIGIT_HUNDREDS        to { m -> "${m.groupValues[1]}${m.groupValues[2]}-hundred${m.groupValues[3]}" },
+    REGEX_4_DIGIT_MIDDLE_ZEROES   to { m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_TENS_AND_TENS   to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_DIGITS_AND_TENS to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_TENS_AND_DIGITS to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_TREBLE_AT_START to { m -> "${m.groupValues[1]}-treble ${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_TREBLE_AT_END   to { m -> "${m.groupValues[1]}${m.groupValues[2]}-treble ${m.groupValues[3]}${m.groupValues[4]}" },
+    REGEX_4_DIGIT_THIRD_DIGIT_0   to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}-oh ${m.groupValues[4]}${m.groupValues[5]}" },
+    REGEX_4_DIGIT_OTHER           to { m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]} ${m.groupValues[5]}${m.groupValues[6]}" }
+)
 
 /**
  * This rather complex helper method manipulates the Android speech engine so instead of saying e.g.
@@ -32,49 +54,16 @@ fun speechify(words: String): String {
             .replace("LiveRide", "Live Ride")
             .replace(Arrivee.ARRIVEE, "arreev eh")
 
-    updatedWords = REGEX_KILOMETRES.replace(updatedWords) {
-        m -> "${m.groupValues[1]} kilometres"
-    }
-    updatedWords = REGEX_METRES.replace(updatedWords) {
-        m -> "${m.groupValues[1]} metres"
+    for (entry in REGEX_METRIC_DISTANCES) {
+        updatedWords = entry.key.replace(updatedWords, entry.value)
     }
 
-    updatedWords = REGEX_THREE_DIGIT_TENS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_THREE_DIGIT_MIDDLE_ZERO.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-oh ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_THREE_DIGIT_OTHER.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]}${m.groupValues[5]}"
+    for (entry in REGEX_3_DIGIT_ROADS) {
+        updatedWords = entry.key.replace(updatedWords, entry.value)
     }
 
-    updatedWords = REGEX_FOUR_DIGIT_HUNDREDS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-hundred${m.groupValues[3]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_MIDDLE_ZEROES.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_TENS_AND_TENS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_DIGITS_AND_TENS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_TENS_AND_DIGITS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_START.replace(updatedWords) {
-        m -> "${m.groupValues[1]}-treble ${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_END.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-treble ${m.groupValues[3]}${m.groupValues[4]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_THIRD_DIGIT_0.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}-oh ${m.groupValues[4]}${m.groupValues[5]}"
-    }
-    updatedWords = REGEX_FOUR_DIGIT_OTHER.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]} ${m.groupValues[5]}${m.groupValues[6]}"
+    for (entry in REGEX_4_DIGIT_ROADS) {
+        updatedWords = entry.key.replace(updatedWords, entry.value)
     }
 
     return updatedWords;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
@@ -7,14 +7,25 @@ private val REGEX_THREE_DIGIT_TENS = "([a-zA-Z])(\\d)([1-9]0)(\\D|\$)".toRegex()
 private val REGEX_THREE_DIGIT_MIDDLE_ZERO= "([a-zA-Z])(\\d)0([1-9])(\\D|\$)".toRegex()   // e.g. A404
 private val REGEX_THREE_DIGIT_OTHER= "([a-zA-Z])(\\d)([1-9])([1-9])(\\D|\$)".toRegex()  // e.g. A467
 
-private val REGEX_FOUR_DIGIT_HUNDREDS = "([a-zA-Z])(\\d[1-9])00(\\D|\$)".toRegex()            // e.g. B1200
-private val REGEX_FOUR_DIGIT_TENS_AND_TENS = "([a-zA-Z])(\\d0)([1-9]0)(\\D|\$)".toRegex()     // e.g. A4030
-private val REGEX_FOUR_DIGIT_MIDDLE_ZEROES = "([a-zA-Z])(\\d)00([1-9])(\\D|\$)".toRegex()     // e.g. B5001
-private val REGEX_FOUR_DIGIT_TREBLE_AT_START = "([a-zA-Z])(\\d)\\2\\2(\\d)(\\D|\$)".toRegex() // e.g. B1113
-private val REGEX_FOUR_DIGIT_TREBLE_AT_END = "([a-zA-Z])(\\d)([1-9])\\3\\3(\\D|\$)".toRegex() // e.g. A2111
-private val REGEX_FOUR_DIGIT_THIRD_DIGIT_0 = "([a-zA-Z])(\\d)([1-9])0([1-9])(\\D|\$)".toRegex() // e.g. A2103
-private val REGEX_FOUR_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])([1-9])(\\D|\$)".toRegex() // e.g. A4123
+private val REGEX_FOUR_DIGIT_HUNDREDS = "([a-zA-Z])(\\d[1-9])00(\\D|\$)".toRegex()               // e.g. B1200
+private val REGEX_FOUR_DIGIT_TENS_AND_TENS = "([a-zA-Z])(\\d0)([1-9]0)(\\D|\$)".toRegex()        // e.g. A4030
+private val REGEX_FOUR_DIGIT_DIGITS_AND_TENS = "([a-zA-Z])(\\d[1-9])([1-9]0)(\\D|\$)".toRegex()  // e.g. A4130
+private val REGEX_FOUR_DIGIT_TENS_AND_DIGITS = "([a-zA-Z])(\\d0)([1-9][1-9])(\\D|\$)".toRegex()  // e.g. A4032
+private val REGEX_FOUR_DIGIT_MIDDLE_ZEROES = "([a-zA-Z])(\\d)00([1-9])(\\D|\$)".toRegex()        // e.g. B5001
+private val REGEX_FOUR_DIGIT_TREBLE_AT_START = "([a-zA-Z])(\\d)\\2\\2(\\d)(\\D|\$)".toRegex()    // e.g. B1113
+private val REGEX_FOUR_DIGIT_TREBLE_AT_END = "([a-zA-Z])(\\d)([1-9])\\3\\3(\\D|\$)".toRegex()    // e.g. A2111
+private val REGEX_FOUR_DIGIT_THIRD_DIGIT_0 = "([a-zA-Z])(\\d)([1-9])0([1-9])(\\D|\$)".toRegex()  // e.g. A2103
+private val REGEX_FOUR_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])([1-9])(\\D|\$)".toRegex()    // e.g. A4123
 
+
+/**
+ * This rather complex helper method manipulates the Android speech engine so instead of saying e.g.
+ * "Bee four thousand one hundred and twenty three" it will correctly call the road "B4123", as
+ * humans would.
+ *
+ * To live test, edit LiveRideState and substitute something like the following for the input to the `speechify()` method.
+ * val testWords = "Testing... B3000 and A200 and A230 and A404 and A467 and B1200 and A4030.  New: A4130 and A4032.  Then B5001 and B1113 and A2111 and A2103 and A4123"
+ */
 fun speechify(words: String): String {
 
     var updatedWords = words
@@ -45,6 +56,12 @@ fun speechify(words: String): String {
         m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_TENS_AND_TENS.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_DIGITS_AND_TENS.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_TENS_AND_DIGITS.replace(updatedWords) {
         m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_START.replace(updatedWords) {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
@@ -29,35 +29,35 @@ fun speechify(words: String): String {
     }
 
     updatedWords = REGEX_THREE_DIGIT_TENS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_THREE_DIGIT_MIDDLE_ZERO.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-oh-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-oh ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_THREE_DIGIT_OTHER.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-${m.groupValues[4]}${m.groupValues[5]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]}${m.groupValues[5]}"
     }
 
     updatedWords = REGEX_FOUR_DIGIT_HUNDREDS.replace(updatedWords) {
         m -> "${m.groupValues[1]}${m.groupValues[2]}-hundred${m.groupValues[3]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_MIDDLE_ZEROES.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_TENS_AND_TENS.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_START.replace(updatedWords) {
-        m -> "${m.groupValues[1]}-treble-${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}-treble ${m.groupValues[2]} ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_END.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-treble-${m.groupValues[3]}${m.groupValues[4]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-treble ${m.groupValues[3]}${m.groupValues[4]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_THIRD_DIGIT_0.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-oh-${m.groupValues[4]}${m.groupValues[5]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]}-oh ${m.groupValues[4]}${m.groupValues[5]}"
     }
     updatedWords = REGEX_FOUR_DIGIT_OTHER.replace(updatedWords) {
-        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-${m.groupValues[4]}-${m.groupValues[5]}${m.groupValues[6]}"
+        m -> "${m.groupValues[1]}${m.groupValues[2]} ${m.groupValues[3]} ${m.groupValues[4]} ${m.groupValues[5]}${m.groupValues[6]}"
     }
 
     return updatedWords;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/SpeechFixer.kt
@@ -3,6 +3,17 @@ package net.cyclestreets.liveride
 private val REGEX_METRES = "(\\d+)m".toRegex()
 private val REGEX_KILOMETRES = "(\\d+)km".toRegex()
 
+private val REGEX_THREE_DIGIT_TENS = "([a-zA-Z])(\\d)([1-9]0)(\\D|\$)".toRegex()         // e.g. A230
+private val REGEX_THREE_DIGIT_MIDDLE_ZERO= "([a-zA-Z])(\\d)0([1-9])(\\D|\$)".toRegex()   // e.g. A404
+private val REGEX_THREE_DIGIT_OTHER= "([a-zA-Z])(\\d)([1-9])([1-9])(\\D|\$)".toRegex()  // e.g. A467
+
+private val REGEX_FOUR_DIGIT_HUNDREDS = "([a-zA-Z])(\\d[1-9])00(\\D|\$)".toRegex()            // e.g. B1200
+private val REGEX_FOUR_DIGIT_TENS_AND_TENS = "([a-zA-Z])(\\d0)([1-9]0)(\\D|\$)".toRegex()     // e.g. A4030
+private val REGEX_FOUR_DIGIT_MIDDLE_ZEROES = "([a-zA-Z])(\\d)00([1-9])(\\D|\$)".toRegex()     // e.g. B5001
+private val REGEX_FOUR_DIGIT_TREBLE_AT_START = "([a-zA-Z])(\\d)\\2\\2(\\d)(\\D|\$)".toRegex() // e.g. B1113
+private val REGEX_FOUR_DIGIT_TREBLE_AT_END = "([a-zA-Z])(\\d)([1-9])\\3\\3(\\D|\$)".toRegex() // e.g. A2111
+private val REGEX_FOUR_DIGIT_THIRD_DIGIT_0 = "([a-zA-Z])(\\d)([1-9])0([1-9])(\\D|\$)".toRegex() // e.g. A2103
+private val REGEX_FOUR_DIGIT_OTHER = "([a-zA-Z])(\\d)([1-9])([1-9])([1-9])(\\D|\$)".toRegex() // e.g. A4123
 
 fun speechify(words: String): String {
 
@@ -11,10 +22,42 @@ fun speechify(words: String): String {
             .replace(Arrivee.ARRIVEE, "arreev eh")
 
     updatedWords = REGEX_KILOMETRES.replace(updatedWords) {
-        matchResult: MatchResult -> "${matchResult.groupValues[1]} kilometres"
+        m -> "${m.groupValues[1]} kilometres"
     }
     updatedWords = REGEX_METRES.replace(updatedWords) {
-        matchResult: MatchResult -> "${matchResult.groupValues[1]} metres"
+        m -> "${m.groupValues[1]} metres"
+    }
+
+    updatedWords = REGEX_THREE_DIGIT_TENS.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_THREE_DIGIT_MIDDLE_ZERO.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-oh-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_THREE_DIGIT_OTHER.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-${m.groupValues[4]}${m.groupValues[5]}"
+    }
+
+    updatedWords = REGEX_FOUR_DIGIT_HUNDREDS.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-hundred${m.groupValues[3]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_MIDDLE_ZEROES.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-double-oh-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_TENS_AND_TENS.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_START.replace(updatedWords) {
+        m -> "${m.groupValues[1]}-treble-${m.groupValues[2]}-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_TREBLE_AT_END.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-treble-${m.groupValues[3]}${m.groupValues[4]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_THIRD_DIGIT_0.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-oh-${m.groupValues[4]}${m.groupValues[5]}"
+    }
+    updatedWords = REGEX_FOUR_DIGIT_OTHER.replace(updatedWords) {
+        m -> "${m.groupValues[1]}${m.groupValues[2]}-${m.groupValues[3]}-${m.groupValues[4]}-${m.groupValues[5]}${m.groupValues[6]}"
     }
 
     return updatedWords;

--- a/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
+++ b/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
@@ -85,14 +85,19 @@ class SpeechFixerTest {
                 .isEqualTo("Straight on onto A40 30. Continue 450 yards onto B20 60")
     }
 
+    @Test
+    fun testFourDigitRoads_TensAndDigits() {
+        // Tokenise into two two-digits numbers,
+        assertThat(speechify("Straight on onto A4021. Continue 450 yards onto B1036"))
+                .isEqualTo("Straight on onto A40 21. Continue 450 yards onto B10 36")
+    }
 
-    //TODO::
-    //    else if either or both two digit separation ends with a zero, tokenise into two two-digits numbers,
-    //    e.g. A1450 => A14 50 => pronounced as "Eh Fourteen Fifty"
-    //    e.g. B2031 => B20 31 => pronounced as "Bee Twenty Thirty-One"
-
-
-
+    @Test
+    fun testFourDigitRoads_DigitsAndTens() {
+        // Tokenise into two two-digits numbers,
+        assertThat(speechify("Straight on onto A1450. Continue 450 yards onto B5620"))
+                .isEqualTo("Straight on onto A14 50. Continue 450 yards onto B56 20")
+    }
 
     @Test
     fun testFourDigitRoads_DoubleOhInMiddle() {

--- a/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
+++ b/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
@@ -30,4 +30,96 @@ class SpeechFixerTest {
                 .isEqualTo("Continue 3.69 kilometres")
     }
 
+    @Test
+    fun testOneAndTwoDigitRoadsUnaffected() {
+        assertThat(speechify("The A45, the B61 and the A3 are not roads you'd want to cycle on. Nor is the A2"))
+                .isEqualTo("The A45, the B61 and the A3 are not roads you'd want to cycle on. Nor is the A2")
+    }
+
+    @Test
+    fun testThreeDigitRoads_Hundreds() {
+        // Leave as-is, e.g. A400 => pronounced as "Eh Four Hundred"
+        assertThat(speechify("Bear right onto A400"))
+                .isEqualTo("Bear right onto A400")
+    }
+
+    @Test
+    fun testThreeDigitRoads_Tens() {
+        // Split into single digit then double, e.g. A230 => A2-30 => pronounced as "Eh Two Thirty"
+        assertThat(speechify("Turn left onto A230. I hate the B450"))
+                .isEqualTo("Turn left onto A2-30. I hate the B4-50")
+    }
+
+    @Test
+    fun testThreeDigitRoads_MiddleZero() {
+        // Split into single digits, and replace the 0 with an "Oh"
+        assertThat(speechify("Turn left onto A404. Then hit the B303"))
+                .isEqualTo("Turn left onto A4-oh-4. Then hit the B3-oh-3")
+    }
+
+    @Test
+    fun testThreeDigitRoads_Other() {
+        // Split into single digits, e.g. B467 => B4 6 7 => pronounced "Bee Four Six Seven"
+        assertThat(speechify("Straight on onto B467. Continue 5.4 miles onto D512"))
+                .isEqualTo("Straight on onto B4-6-7. Continue 5.4 miles onto D5-1-2")
+    }
+
+    @Test
+    fun testFourDigitRoads_Thousand() {
+        // Leave as-is, e.g. A3000 => pronounced as "Eh Three Thousand"
+        assertThat(speechify("Straight on onto A3000. Continue 450 yards onto E1000"))
+                .isEqualTo("Straight on onto A3000. Continue 450 yards onto E1000")
+    }
+
+    @Test
+    fun testFourDigitRoads_Hundred() {
+        // Split off the "hundred", e.g. B1200 => B12 hundred => pronounced as "Bee Twelve Hundred"
+        assertThat(speechify("Straight on onto B1200. Continue 450 yards onto B2500"))
+                .isEqualTo("Straight on onto B12-hundred. Continue 450 yards onto B25-hundred")
+    }
+
+    @Test
+    fun testFourDigitRoads_TensAndTens() {
+        // Tokenise into two two-digits numbers,
+        assertThat(speechify("Straight on onto A4030. Continue 450 yards onto B2060"))
+                .isEqualTo("Straight on onto A40-30. Continue 450 yards onto B20-60")
+    }
+
+
+    //TODO::
+    //    else if either or both two digit separation ends with a zero, tokenise into two two-digits numbers,
+    //    e.g. A1450 => A14 50 => pronounced as "Eh Fourteen Fifty"
+    //    e.g. B2031 => B20 31 => pronounced as "Bee Twenty Thirty-One"
+
+
+
+
+    @Test
+    fun testFourDigitRoads_DoubleOhInMiddle() {
+        // Pronounce a "double-oh" in the middle.
+        assertThat(speechify("Straight on onto A5002. Continue 450 yards onto B5003"))
+                .isEqualTo("Straight on onto A5-double-oh-2. Continue 450 yards onto B5-double-oh-3")
+    }
+
+    @Test
+    fun testFourDigitRoads_WithTrebleNumbers() {
+        // Capture trebles, e.g. B1113 => B-treble-1-3=> pronounced as "Bee Treble One Three"
+        assertThat(speechify("Straight on onto A1113. Continue 450 yards onto B4111"))
+                .isEqualTo("Straight on onto A-treble-1-3. Continue 450 yards onto B4-treble-1")
+    }
+
+    @Test
+    fun testFourDigitRoads_ThirdDigitOh() {
+        // Pronounce each digit individually, but 0 as "oh".
+        assertThat(speechify("Straight on onto A2103. Continue 450 yards onto B4204"))
+                .isEqualTo("Straight on onto A2-1-oh-3. Continue 450 yards onto B4-2-oh-4")
+    }
+
+    @Test
+    fun testFourDigitRoads_Other() {
+        // otherwise, split into single digits, e.g. A4123 => A4 1 2 3 => pronounced as "Eh Four One Two Three"
+        assertThat(speechify("Straight on onto A4123. Continue 450 yards onto B5678"))
+                .isEqualTo("Straight on onto A4-1-2-3. Continue 450 yards onto B5-6-7-8")
+    }
+
 }

--- a/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
+++ b/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/SpeechFixerTest.kt
@@ -47,21 +47,21 @@ class SpeechFixerTest {
     fun testThreeDigitRoads_Tens() {
         // Split into single digit then double, e.g. A230 => A2-30 => pronounced as "Eh Two Thirty"
         assertThat(speechify("Turn left onto A230. I hate the B450"))
-                .isEqualTo("Turn left onto A2-30. I hate the B4-50")
+                .isEqualTo("Turn left onto A2 30. I hate the B4 50")
     }
 
     @Test
     fun testThreeDigitRoads_MiddleZero() {
         // Split into single digits, and replace the 0 with an "Oh"
         assertThat(speechify("Turn left onto A404. Then hit the B303"))
-                .isEqualTo("Turn left onto A4-oh-4. Then hit the B3-oh-3")
+                .isEqualTo("Turn left onto A4-oh 4. Then hit the B3-oh 3")
     }
 
     @Test
     fun testThreeDigitRoads_Other() {
         // Split into single digits, e.g. B467 => B4 6 7 => pronounced "Bee Four Six Seven"
         assertThat(speechify("Straight on onto B467. Continue 5.4 miles onto D512"))
-                .isEqualTo("Straight on onto B4-6-7. Continue 5.4 miles onto D5-1-2")
+                .isEqualTo("Straight on onto B4 6 7. Continue 5.4 miles onto D5 1 2")
     }
 
     @Test
@@ -82,7 +82,7 @@ class SpeechFixerTest {
     fun testFourDigitRoads_TensAndTens() {
         // Tokenise into two two-digits numbers,
         assertThat(speechify("Straight on onto A4030. Continue 450 yards onto B2060"))
-                .isEqualTo("Straight on onto A40-30. Continue 450 yards onto B20-60")
+                .isEqualTo("Straight on onto A40 30. Continue 450 yards onto B20 60")
     }
 
 
@@ -98,28 +98,28 @@ class SpeechFixerTest {
     fun testFourDigitRoads_DoubleOhInMiddle() {
         // Pronounce a "double-oh" in the middle.
         assertThat(speechify("Straight on onto A5002. Continue 450 yards onto B5003"))
-                .isEqualTo("Straight on onto A5-double-oh-2. Continue 450 yards onto B5-double-oh-3")
+                .isEqualTo("Straight on onto A5-double-oh 2. Continue 450 yards onto B5-double-oh 3")
     }
 
     @Test
     fun testFourDigitRoads_WithTrebleNumbers() {
         // Capture trebles, e.g. B1113 => B-treble-1-3=> pronounced as "Bee Treble One Three"
         assertThat(speechify("Straight on onto A1113. Continue 450 yards onto B4111"))
-                .isEqualTo("Straight on onto A-treble-1-3. Continue 450 yards onto B4-treble-1")
+                .isEqualTo("Straight on onto A-treble 1 3. Continue 450 yards onto B4-treble 1")
     }
 
     @Test
     fun testFourDigitRoads_ThirdDigitOh() {
         // Pronounce each digit individually, but 0 as "oh".
         assertThat(speechify("Straight on onto A2103. Continue 450 yards onto B4204"))
-                .isEqualTo("Straight on onto A2-1-oh-3. Continue 450 yards onto B4-2-oh-4")
+                .isEqualTo("Straight on onto A2 1-oh 3. Continue 450 yards onto B4 2-oh 4")
     }
 
     @Test
     fun testFourDigitRoads_Other() {
         // otherwise, split into single digits, e.g. A4123 => A4 1 2 3 => pronounced as "Eh Four One Two Three"
         assertThat(speechify("Straight on onto A4123. Continue 450 yards onto B5678"))
-                .isEqualTo("Straight on onto A4-1-2-3. Continue 450 yards onto B5-6-7-8")
+                .isEqualTo("Straight on onto A4 1 2 3. Continue 450 yards onto B5 6 7 8")
     }
 
 }


### PR DESCRIPTION
Closes #393.

I have tested this in the emulator and it sounds good to me in the cases I tried.

If anyone's interested, hyphens don't work, because it sometimes reads them out as "minus" 😂 