### PR TITLE
404: classic Kotlin parameter nullability bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ buildscript {
 }
 
 ext {
+  // From e.g. https://source.android.com/setup/start/build-numbers
+  // Android 10          29  Q
   // Android 9.0         28  PIE
   // Android 8.1         27  OREO_MR1
   // Android 8.0         26  OREO
@@ -25,6 +27,7 @@ ext {
   // Android 4.2, 4.2.2  17  JELLY_BEAN_MR1
 
   // Remember to keep these values in sync with .travis.yml
+  // TODO: upgrade at least compileSdkVersion to 29
   compileSdkVersion=28
   minSdkVersion=23
   targetSdkVersion=28

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/LocationsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/LocationsFragment.kt
@@ -131,7 +131,7 @@ class LocationsFragment : ListFragment() {
             return locations[position].localId().toLong()
         }
 
-        override fun getView(position: Int, convertView: View, parent: ViewGroup): View {
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             val location = locations[position]
             val v = inflater.inflate(R.layout.storedroutes_item, parent, false)
 


### PR DESCRIPTION
Closes #404.

The Javadoc for this parameter explicitly says:
> You should check that this view is non-null and of an appropriate type before using.

So it's just an artifact of the migration to Kotlin that this is failing.  (Because we haven't got round to making this stuff as finely tuned as it could be, we don't even use this parameter, so the crash is entirely unnecessary...!)
