### PR TITLE
If we don't restore to a page, force to the journey planner

### DIFF
--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
@@ -185,7 +185,8 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
 
     public override fun onResume() {
         val selectedItem = prefs().getInt(DRAWER_ITEMID_SELECTED_KEY, R.id.nav_journey_planner)
-        showPage(selectedItem)
+        if (!showPage(selectedItem))
+            showPage(R.id.nav_journey_planner)
         super.onResume()
         Route.registerListener(this)
         setBlogStateTitle()


### PR DESCRIPTION
It appears that on upgrade we don't always get a sensible selectedItem
value back in MainNavDrawerActivity.onResume. In this case, if showPage
fails, call it again specifying the journay planner.