### PR TITLE
Add overlay to mark Find Place on map

### DIFF
--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -9,6 +9,7 @@
 <strong>Features:</strong>
 <ul>
   <li>POI URLs (e.g. bike shop websites) now appear as clickable links.</li>
+  <li>Find a Place now puts a marker on the screen instead of just centering the map.</li>
 </ul>
 <strong>Bug fixes:</strong>
 <ul>

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,3 +1,4 @@
 POI URLs (e.g. bike shop websites) now appear as clickable links.
+Find a Place now puts a marker on the screen instead of just centering the map
 
 Various minor bug fixes.

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
@@ -147,7 +147,7 @@ open class CycleMapFragment : Fragment(), Undoable {
 
     private fun launchFindDialog() {
         FindPlace.launch(requireContext(), map!!.boundingBox) { place ->
-            map!!.centreOn(place, FINDPLACE_ZOOM_LEVEL)
+            map!!.centreOn(place, FINDPLACE_ZOOM_LEVEL, true)
         }
     }
 

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/RouteMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/RouteMapFragment.kt
@@ -3,10 +3,6 @@ package net.cyclestreets
 import net.cyclestreets.fragments.R
 import net.cyclestreets.iconics.IconicsHelper
 import net.cyclestreets.util.*
-import net.cyclestreets.views.overlay.POIOverlay
-import net.cyclestreets.views.overlay.RouteOverlay
-import net.cyclestreets.views.overlay.RouteHighlightOverlay
-import net.cyclestreets.views.overlay.TapToRouteOverlay
 import net.cyclestreets.routing.Journey
 import net.cyclestreets.routing.Route
 import net.cyclestreets.routing.Waypoints
@@ -24,6 +20,7 @@ import android.view.ViewGroup
 
 import net.cyclestreets.util.MenuHelper.enableMenuItem
 import net.cyclestreets.util.MenuHelper.showMenuItem
+import net.cyclestreets.views.overlay.*
 
 private val TAG = Logging.getTag(RouteMapFragment::class.java)
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/ControllerOverlay.java
@@ -106,6 +106,13 @@ public class ControllerOverlay extends Overlay implements OnDoubleTapListener, O
         undoStack_.remove(i);
   }
 
+  public boolean checkUndo(final Undoable undo) {
+    for (int i = undoStack_.size() - 1; i >= 0; --i)
+      if (undoStack_.get(i).equals(undo))
+        return true;
+      return false;
+  }
+
   public void popUndo(final Undoable undo) {
     for (int i = undoStack_.size() - 1; i >= 0; --i)
       if (undoStack_.get(i).equals(undo)) {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/FindPlaceOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/FindPlaceOverlay.kt
@@ -17,26 +17,26 @@ import org.osmdroid.views.overlay.Overlay
 
 class FindPlaceOverlay(context: Context, cycleMapView: CycleMapView) : Overlay(), Undoable {
     // (Passing CMV as parm so centreOn can be accessed, which we need to calc screen coords)
-    private val placeMarker_: Drawable?
-    private var cMapView_: CycleMapView
+    private val placeMarker: Drawable
+    private var cMapView: CycleMapView
     private var halfWidth: Int = 0
     private var halfHeight: Int = 0
 
     private val controller = OverlayHelper(cycleMapView).controller()
 
     init {
-        val res: Resources = context.getResources()
-        placeMarker_ = ResourcesCompat.getDrawable(res, R.drawable.x_marks_spot, null)
-        if (placeMarker_ != null) {
-            halfWidth = placeMarker_.intrinsicWidth / 2
-            halfHeight = placeMarker_.intrinsicHeight / 2
-        }
-        cMapView_ = cycleMapView
+        val res: Resources = context.resources
+        placeMarker = ResourcesCompat.getDrawable(res, R.drawable.x_marks_spot, null)!!
+
+        halfWidth = placeMarker.intrinsicWidth / 2
+        halfHeight = placeMarker.intrinsicHeight / 2
+
+        cMapView = cycleMapView
     }
 
     override fun draw(canvas: Canvas, mapView: MapView, shadow: Boolean) {
-        val foundPlace: IGeoPoint? = cMapView_.getFoundPlace()
-        if ((foundPlace == null) || (placeMarker_ == null)) return
+        val foundPlace: IGeoPoint? = cMapView.getFoundPlace()
+        if (foundPlace == null) return
 
         if (!controller.checkUndo(this))
             controller.pushUndo(this)
@@ -45,20 +45,20 @@ class FindPlaceOverlay(context: Context, cycleMapView: CycleMapView) : Overlay()
         val projection: IProjection = mapView.projection
         projection.toPixels(foundPlace, screenPos)
 
-        placeMarker_.bounds = Rect(screenPos.x - halfWidth,
+        placeMarker.bounds = Rect(screenPos.x - halfWidth,
                 screenPos.y - halfHeight,
                 screenPos.x + halfWidth,
                 screenPos.y + halfHeight)
-        placeMarker_.draw(canvas)
+        placeMarker.draw(canvas)
     }
 
     protected fun redraw() {
-        cMapView_.postInvalidate()
+        cMapView.postInvalidate()
     }
 
     override fun onBackPressed(): Boolean {
         controller.flushUndo(this)
-        cMapView_.setFoundPlace(null)
+        cMapView.setFoundPlace(null)
         redraw()
         return true
     }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/FindPlaceOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/FindPlaceOverlay.kt
@@ -1,0 +1,66 @@
+package net.cyclestreets.views.overlay
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Canvas
+import android.graphics.Point
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.core.content.res.ResourcesCompat
+import net.cyclestreets.Undoable
+import net.cyclestreets.view.R
+import net.cyclestreets.views.CycleMapView
+import org.osmdroid.api.IGeoPoint
+import org.osmdroid.api.IProjection
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Overlay
+
+class FindPlaceOverlay(context: Context, cycleMapView: CycleMapView) : Overlay(), Undoable {
+    // (Passing CMV as parm so centreOn can be accessed, which we need to calc screen coords)
+    private val placeMarker_: Drawable?
+    private var cMapView_: CycleMapView
+    private var halfWidth: Int = 0
+    private var halfHeight: Int = 0
+
+    private val controller = OverlayHelper(cycleMapView).controller()
+
+    init {
+        val res: Resources = context.getResources()
+        placeMarker_ = ResourcesCompat.getDrawable(res, R.drawable.x_marks_spot, null)
+        if (placeMarker_ != null) {
+            halfWidth = placeMarker_.intrinsicWidth / 2
+            halfHeight = placeMarker_.intrinsicHeight / 2
+        }
+        cMapView_ = cycleMapView
+    }
+
+    override fun draw(canvas: Canvas, mapView: MapView, shadow: Boolean) {
+        val foundPlace: IGeoPoint? = cMapView_.getFoundPlace()
+        if ((foundPlace == null) || (placeMarker_ == null)) return
+
+        if (!controller.checkUndo(this))
+            controller.pushUndo(this)
+
+        val screenPos = Point()
+        val projection: IProjection = mapView.projection
+        projection.toPixels(foundPlace, screenPos)
+
+        placeMarker_.bounds = Rect(screenPos.x - halfWidth,
+                screenPos.y - halfHeight,
+                screenPos.x + halfWidth,
+                screenPos.y + halfHeight)
+        placeMarker_.draw(canvas)
+    }
+
+    protected fun redraw() {
+        cMapView_.postInvalidate()
+    }
+
+    override fun onBackPressed(): Boolean {
+        controller.flushUndo(this)
+        cMapView_.setFoundPlace(null)
+        redraw()
+        return true
+    }
+
+}

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
@@ -60,7 +60,7 @@ public abstract class LiveItemOverlay<T extends OverlayItem>
   protected float cornerRadius() { return radius_; }
 
   protected void centreOn(IGeoPoint geoPoint) {
-    mapView_.centreOn(geoPoint, ITEM_ZOOM_LEVEL);
+    mapView_.centreOn(geoPoint, ITEM_ZOOM_LEVEL, false);
   }
 
   @Override


### PR DESCRIPTION
Fixes #428 

I used the "There" marker from the location editor (the red cross) for the Find Place marker.

Tested the following (see attached pdf for more detail):
Journey Planner
Photo map
Move screen
Zoom in and out
Combine with POI's, Waymarks, route highlight, location, various combinations
Back button (for the various combinations above)
Follow location
[Test FInd Place marker 200721.pdf](https://github.com/cyclestreets/android/files/4956019/Test.FInd.Place.marker.200721.pdf)

Screenshot with the marker:

![Screenshot_1594731460](https://user-images.githubusercontent.com/59799824/88103219-a14f0780-cb98-11ea-9398-e8c5f29b9fb7.png)


