### PR TITLE
Rip out vector mapfile setting

### DIFF
--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/SettingsFragment.kt
@@ -22,7 +22,6 @@ private const val PREFERENCE_SCREEN_ARG: String = "preferenceScreenArg"
 private val SETTINGS_ICONS = mapOf(
     "screen-maps-display" to GoogleMaterial.Icon.gmd_map,
     "mapstyle" to null,
-    "mapfile" to null,
     "confirm-new-route" to null,
     "screen-routing-preferences" to GoogleMaterial.Icon.gmd_directions,
     "routetype" to null,
@@ -50,13 +49,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         super.onCreate(savedInstance)
 
         setupMapStyles()
-        setupMapFileList()
 
         setSummary(CycleStreetsPreferences.PREF_ROUTE_TYPE_KEY)
         setSummary(CycleStreetsPreferences.PREF_UNITS_KEY)
         setSummary(CycleStreetsPreferences.PREF_SPEED_KEY)
         setSummary(CycleStreetsPreferences.PREF_MAPSTYLE_KEY)
-        setSummary(CycleStreetsPreferences.PREF_MAPFILE_KEY)
         setSummary(CycleStreetsPreferences.PREF_UPLOAD_SIZE)
         setSummary(CycleStreetsPreferences.PREF_NEARING_TURN)
         setSummary(CycleStreetsPreferences.PREF_OFFTRACK_DISTANCE)
@@ -117,27 +114,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     private fun setupMapStyles() {
         findPreference<ListPreference>(CycleStreetsPreferences.PREF_MAPSTYLE_KEY)?.apply {
-
-            if (this.value == CycleStreetsPreferences.MAPSTYLE_MAPSFORGE && MapPack.availableMapPacks(context).isEmpty()) {
-                Log.i(TAG, "Offline Vector Maps were selected, but there are no available map packs; default to OSM")
-                this.value = CycleStreetsPreferences.MAPSTYLE_OSM
-            }
-
-            TileSource.configurePreference(this)
+           TileSource.configurePreference(this)
         }
-    }
-
-    private fun setupMapFileList() {
-        findPreference<ListPreference>(CycleStreetsPreferences.PREF_MAPFILE_KEY)?.apply {
-            populateMapFileList(this)
-        }
-    }
-
-    private fun populateMapFileList(mapfilePref: ListPreference) {
-        val names = MapPack.availableMapPacks(context).map { pack: MapPack -> pack.name() }
-        val files = MapPack.availableMapPacks(context).map { pack: MapPack -> pack.path() }
-        mapfilePref.entries = names.toTypedArray()
-        mapfilePref.entryValues = files.toTypedArray()
     }
 
     override fun onResume() {
@@ -165,37 +143,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             prefUI.summary = prefUI.entry
         if (prefUI is EditTextPreference)
             prefUI.summary = prefUI.text
+   }
 
-        if (CycleStreetsPreferences.PREF_MAPSTYLE_KEY == key)
-            setMapFileSummary((prefUI as ListPreference).value)
-    }
-
-    private fun setMapFileSummary(style: String) {
-        val pref = findPreference<Preference>(CycleStreetsPreferences.PREF_MAPFILE_KEY) ?: return
-        val mapfilePref = pref as ListPreference
-
-        val enabled = style == CycleStreetsPreferences.MAPSTYLE_MAPSFORGE
-        mapfilePref.isEnabled = enabled
-
-        if (!enabled)
-            return
-
-        if (mapfilePref.entryValues.isEmpty()) {
-            mapfilePref.isEnabled = false
-            MessageBox.YesNo(requireView(), R.string.settings_no_map_packs) { _, _ -> MapPack.searchGooglePlay(requireContext()) }
-            return
-        }
-
-        val mapfile = CycleStreetsPreferences.mapfile()
-        var index = mapfilePref.findIndexOfValue(mapfile)
-        if (index == -1)
-            index = 0 // default to something
-
-        mapfilePref.setValueIndex(index)
-        mapfilePref.summary = mapfilePref.entries[index]
-    }
-
-    private fun setAccountSummary() {
+   private fun setAccountSummary() {
         val pref = findPreference<Preference>(CycleStreetsPreferences.PREF_ACCOUNT_KEY) ?: return
         val account = pref as PreferenceScreen
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/tiles/TileSource.java
@@ -197,7 +197,6 @@ public class TileSource {
     addTileSource("OpenCycleMap (shows hills)", OPENCYCLEMAP);
     addTileSource("OpenStreetMap default style", OPENSTREETMAP);
     addTileSource("Ordnance Survey OpenData", OSMAP);
-    addTileSource("Offline Vector Maps", MAPSFORGE);
 
     builtInsAdded_ = true;
   }

--- a/libraries/cyclestreets-view/src/main/res/xml/prefs.xml
+++ b/libraries/cyclestreets-view/src/main/res/xml/prefs.xml
@@ -9,9 +9,6 @@
         android:title="Map style"
         android:summary="OpenStreetMap"
         android:defaultValue="CycleStreets-OSM" />
-    <ListPreference
-        android:key="mapfile"
-        android:title="Vector mapfile" />
     <CheckBoxPreference
         android:key="confirm-new-route"
         android:title="Confirm start new route"


### PR DESCRIPTION
Closes #436.

It's causing crashes on some phones, and will be replaced with a new
mechanism soon, see PR #417.