### PR TITLE
Fix permissions for LiveRide, and generally improve how we request permissions.

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
@@ -38,6 +38,8 @@ public class CycleStreetsPreferences
   public final static String PREF_SHOW_REMAINING_TIME = "show-remaining-time";
   public final static String PREF_SHOW_ETA = "show-ETA";
 
+  public static final String PREF_PERMISSION_REQUESTED_PREFIX = "permission-requested-";
+
   public final static String MAPSTYLE_OCM = "CycleStreets";
   public final static String MAPSTYLE_OSM = "CycleStreets-OSM";
   public final static String MAPSTYLE_OS = "CycleStreets-OS";
@@ -144,6 +146,14 @@ public class CycleStreetsPreferences
 
   public static boolean showEta() {
     return getBoolean(PREF_SHOW_ETA, true);
+  }
+
+  public static boolean permissionPreviouslyRequested(String permission) {
+    return getBoolean(PREF_PERMISSION_REQUESTED_PREFIX + permission, false);
+  }
+
+  public static void logPermissionAsRequested(String permission) {
+    putBoolean(PREF_PERMISSION_REQUESTED_PREFIX + permission, true);
   }
 
   public static boolean uploadSmallImages() {

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
@@ -70,7 +70,7 @@ open class CycleMapFragment : Fragment(), Undoable {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
-        Log.d(TAG, "Permissions granted (with 0) or denied (with -1): ${permissions.joinToString()}, ${grantResults.joinToString()}")
+        Log.d(TAG, "Permission ${permissions.joinToString()} was ${if (grantResults.joinToString().equals("0")) "granted" else "denied"}")
 
         for (i in permissions.indices) {
             val permission = permissions[i]

--- a/libraries/cyclestreets-view/src/main/AndroidManifest.xml
+++ b/libraries/cyclestreets-view/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
               android:launchMode="singleTop"
               android:screenOrientation="portrait" />
 
-    <service android:name="net.cyclestreets.liveride.LiveRideService" />
+    <service android:name="net.cyclestreets.liveride.LiveRideService"
+        android:foregroundServiceType="location"/>
   </application>
 </manifest>

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
@@ -4,11 +4,20 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
 import android.content.pm.PackageManager
-import androidx.fragment.app.Fragment
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat.startActivity
+import androidx.fragment.app.Fragment
+import net.cyclestreets.CycleStreetsPreferences.logPermissionAsRequested
+import net.cyclestreets.CycleStreetsPreferences.permissionPreviouslyRequested
 import net.cyclestreets.util.Permissions.justifications
 import net.cyclestreets.view.R
+
 
 private val TAG = Logging.getTag(Permissions::class.java)
 
@@ -17,30 +26,49 @@ fun hasPermission(context: Context, permission: String): Boolean {
     return context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
 }
 
+// See https://stackoverflow.com/questions/32347532/android-m-permissions-confused-on-the-usage-of-shouldshowrequestpermissionrati
+// for some details about the different "requesting permissions" context that Android has.
+
 // Do or request permission - from activity, fragment, or (with hackery) context
 fun doOrRequestPermission(activity: Activity, permission: String, action: () -> Unit) {
     if (hasPermission(activity, permission))
+        // all good, carry on
         action()
     else {
-        if (activity.shouldShowRequestPermissionRationale(permission)) {
-            MessageBox.OkHtml(activity, justification(activity, permission)) {
-                    _, _ -> requestPermission(activity, permission)
+        if (!permissionPreviouslyRequested(permission) || activity.shouldShowRequestPermissionRationale(permission)) {
+            // Give details of why we're asking for permission, be it when we ask for the first time
+            // or after a user clicked "deny" the first time
+            logPermissionAsRequested(permission)
+            MessageBox.OkHtml(activity, justification(activity, permission)) { _, _ ->
+                requestPermission(activity, permission)
             }
-        } else
-            requestPermission(activity, permission)
+        } else {
+            // User has previously denied, and said "don't ask me again".  Tell them they'll have to go into app settings now.
+            MessageBox.OkHtml(activity, justificationAfterDenial(activity, permission)) { _, _ ->
+                goToSettings(activity)
+            }
+        }
     }
 }
 fun doOrRequestPermission(fragment: Fragment, permission: String, action: () -> Unit) {
     val context = fragment.requireContext()
     if (hasPermission(context, permission))
+        // all good, carry on
         action()
     else {
-        if (fragment.shouldShowRequestPermissionRationale(permission)) {
-            MessageBox.OkHtml(context, justification(context, permission)) {
-                    _, _ -> requestPermission(fragment, permission)
+        if (!permissionPreviouslyRequested(permission) || fragment.shouldShowRequestPermissionRationale(permission)) {
+            // Give details of why we're asking for permission, be it when we ask for the first time
+            // or after a user clicked "deny" the first time
+            logPermissionAsRequested(permission)
+            MessageBox.OkHtml(context, justification(context, permission)) { _, _ ->
+                requestPermission(fragment, permission)
             }
-        } else
-            requestPermission(fragment, permission)
+        } else {
+            // User has previously denied, and said "don't ask me again".  Tell them they'll have to go into app settings now.
+            MessageBox.OkHtml(context, justificationAfterDenial(context, permission)) { _, _ ->
+                goToSettings(context)
+            }
+        }
     }
 }
 fun doOrRequestPermission(context: Context, permission: String, action: () -> Unit) {
@@ -54,7 +82,7 @@ private fun activityFromContext(initialContext: Context): Activity? {
         if (context is Activity) {
             return context
         }
-        context = context.baseContext;
+        context = context.baseContext
     }
     return null
 }
@@ -71,9 +99,23 @@ private fun requestPermission(fragment: Fragment, permission: String) {
     }
 }
 
+// Go to settings - if dynamic permission requesting is no long an option
+@RequiresApi(api = Build.VERSION_CODES.M)
+private fun goToSettings(context: Context) {
+    val androidAppSettingsIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:net.cyclestreets"))
+            .addCategory(Intent.CATEGORY_DEFAULT)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    startActivity(context, androidAppSettingsIntent, null)
+}
+
+// justifications
 private fun justification(context: Context, permission: String): String {
     val reason = context.getString(justifications[permission]!!)
-    return context.getString(R.string.perm_justification_format, "<ul>$reason</ul>")
+    return context.getString(R.string.perm_justification_format, reason)
+}
+private fun justificationAfterDenial(context: Context, permission: String): String {
+    val reason = context.getString(justifications[permission]!!)
+    return context.getString(R.string.perm_justification_after_denial_format, reason)
 }
 
 private object Permissions {

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -123,35 +123,38 @@
 
   <!-- Permission justifications -->
   <string name="perm_justification_format" translatable="false"><![CDATA[
-    <p>In the next dialog, you will have the opportunity to grant a permission to this app.  We would like to use this permission in order to:</p>%1$s
+    <p>In the next dialog, this app will request permission to <em>%1$s</em>.</p>
+    <p>This permission will be used to:</p>%2$s
   ]]></string>
   <string name="perm_justification_after_denial_format" translatable="false"><![CDATA[
-    <p>You have previously denied a permission to this app that is required for the functionality you are trying to access.  In the next step, you will be taken to the application settings page to give you an opportunity to change this.  We would like to use this permission in order to:</p>%1$s
+    <p>You have previously denied this app the permission to <em>%1$s</em>.  It is required for the functionality you are trying to access.  In the next step, you will be taken to the application settings page to give you an opportunity to change this.</p>
+    <p>This permission will be used to:</p>%2$s
   ]]></string>
   <string name="perm_justification_read_external_storage" translatable="false"><![CDATA[
     <ul>
-      <li>&nbsp; read cached map tiles that have been downloaded <b>(required - the app cannot function without this)</b></li>
-      <li>&nbsp; allow you to select photographs from your image library for use by the Add Photo feature</li>
+      <li>&nbsp; read cached map tiles that have been downloaded</li>
+      <li>&nbsp; allow you to select photographs from your image library for use in the Add Photo feature.</li>
     </ul>
   ]]></string>
   <string name="perm_justification_write_external_storage" translatable="false"><![CDATA[
     <ul>
-      <li>&nbsp; cache downloaded map tiles <b>(required - the app cannot function without this)</b></li>
-      <li>&nbsp; allow your camera app to directly take photographs for use by the Add Photo feature</li>
+      <li>&nbsp; cache downloaded map tiles <b>(without this the app will function poorly and consume much more data)</b></li>
+      <li>&nbsp; allow your camera app to directly take photographs in the Add Photo feature.</li>
     </ul>
   ]]></string>
   <string name="perm_justification_access_fine_location" translatable="false"><![CDATA[
     <ul>
-      <li>&nbsp; centre the map on your location</li>
-      <li>&nbsp; give turn-by-turn voice navigation directions (the LiveRide feature)</li>
+      <li>&nbsp; centre the map on your location when requested</li>
+      <li>&nbsp; give turn-by-turn voice navigation directions (the LiveRide feature).</li>
     </ul>
-    <p>Your location information / history is not stored anywhere, and is only sent to our servers if a new route is dynamically planned from your location after deviating from a planned route in LiveRide; and in this case, our servers have no way of distinguishing this from a normal route planning operation.</p>
+    <p>Your location history is not stored anywhere, locally or remotely.</p>
+    <p>Your current location may only be sent to our servers when planning a route from your current location.</p>
   ]]></string>
   <string name="perm_justification_read_contacts" translatable="false"><![CDATA[
     <ul>
-      <li>&nbsp; allow you to find the addresses of your contacts on the map, and create routes to these locations</li>
+      <li>&nbsp; allow you to find the addresses of your contacts on the map, and create routes to these locations.</li>
     </ul>
-    <p>Your contact information is not stored anywhere, and is only sent to our servers for the purposes of planning a route.</p>
+    <p>Your contact information is not stored anywhere, locally or remotely, and is only sent to our servers for the purposes of planning a route.</p>
   ]]></string>
 
   <string name="show_remaining_time">Show remaining time</string>

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -125,20 +125,35 @@
   <string name="perm_justification_format" translatable="false"><![CDATA[
     <p>In the next dialog, you will have the opportunity to grant a permission to this app.  We would like to use this permission in order to:</p>%1$s
   ]]></string>
+  <string name="perm_justification_after_denial_format" translatable="false"><![CDATA[
+    <p>You have previously denied a permission to this app that is required for the functionality you are trying to access.  In the next step, you will be taken to the application settings page to give you an opportunity to change this.  We would like to use this permission in order to:</p>%1$s
+  ]]></string>
   <string name="perm_justification_read_external_storage" translatable="false"><![CDATA[
-    <li>&nbsp; allow you to select photographs from your image library for use by the Add Photo feature</li>
+    <ul>
+      <li>&nbsp; read cached map tiles that have been downloaded <b>(required - the app cannot function without this)</b></li>
+      <li>&nbsp; allow you to select photographs from your image library for use by the Add Photo feature</li>
+    </ul>
   ]]></string>
   <string name="perm_justification_write_external_storage" translatable="false"><![CDATA[
-    <li>&nbsp; optimize map performance by caching downloaded map tiles</li>
-    <li>&nbsp; allow your camera app to directly take photographs for use by the Add Photo feature</li>
+    <ul>
+      <li>&nbsp; cache downloaded map tiles <b>(required - the app cannot function without this)</b></li>
+      <li>&nbsp; allow your camera app to directly take photographs for use by the Add Photo feature</li>
+    </ul>
   ]]></string>
   <string name="perm_justification_access_fine_location" translatable="false"><![CDATA[
-    <li>&nbsp; centre the map on your location</li>
-    <li>&nbsp; give turn-by-turn navigation directions (the LiveRide feature)</li>
+    <ul>
+      <li>&nbsp; centre the map on your location</li>
+      <li>&nbsp; give turn-by-turn voice navigation directions (the LiveRide feature)</li>
+    </ul>
+    <p>Your location information / history is not stored anywhere, and is only sent to our servers if a new route is dynamically planned from your location after deviating from a planned route in LiveRide; and in this case, our servers have no way of distinguishing this from a normal route planning operation.</p>
   ]]></string>
   <string name="perm_justification_read_contacts" translatable="false"><![CDATA[
-    <li>&nbsp; allow you to find the addresses of your contacts on the map, and create routes to these locations</li>
+    <ul>
+      <li>&nbsp; allow you to find the addresses of your contacts on the map, and create routes to these locations</li>
+    </ul>
+    <p>Your contact information is not stored anywhere, and is only sent to our servers for the purposes of planning a route.</p>
   ]]></string>
+
   <string name="show_remaining_time">Show remaining time</string>
   <string name="show_ETA">Show estimated time of arrival</string>
   <string name="remaining">Remaining</string>

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -125,10 +125,12 @@
   <string name="perm_justification_format" translatable="false"><![CDATA[
     <p>In the next dialog, this app will request permission to <em>%1$s</em>.</p>
     <p>This permission will be used to:</p>%2$s
+    <p>This can be independently verified as our app is open source.</p>
   ]]></string>
   <string name="perm_justification_after_denial_format" translatable="false"><![CDATA[
     <p>You have previously denied this app the permission to <em>%1$s</em>.  It is required for the functionality you are trying to access.  In the next step, you will be taken to the application settings page to give you an opportunity to change this.</p>
     <p>This permission will be used to:</p>%2$s
+    <p>This can be independently verified as our app is open source.</p>
   ]]></string>
   <string name="perm_justification_read_external_storage" translatable="false"><![CDATA[
     <ul>


### PR DESCRIPTION
Closes #429, #411.

Supercedes #438.

The idea of this is to:
- take what @HilaryN figured out in #438 and apply that (the first commit)
- improve the "justification" screens that give context for why we're asking for permissions, by:
   - making the text clearer and more thorough
   - always including them (including before first attempt to request, unlike previously)
   - if the user has clicked "Deny" and "Never ask again" then actions which require a given permission should now give an updated justification message, and then take the user to the app settings screen directly, from where they have an opportunity to grant the permission (previously, in this scenario no justification would be seen and no opportunity to change permissions would be given, meaning the functionality - e.g. clicking LiveRide - would just do nothing).

@jezhiggins and @HilaryN, please review.

@HilaryN, is there any chance you could please do some of your thorough testing on a variety of versions, to check the behaviour is as I intended in the description above?  (I haven't got the time to test just now, but managed to squeeze in the coding herein).

Cheers.