### PR TITLE
Update compile SDK from 29 (Android 10) to 30 (Android 11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ android:
 before_install:
   - ./ciLicense.sh
   - sudo pip install requests
+  - touch $HOME/.android/repositories.cfg
+  - yes | sdkmanager "platforms;android-30"
+  - yes | sdkmanager "build-tools;30.0.2"
 
 install:
   - ./checkPoiTypeIcons.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - compileSdkVersion=30
     - minSdkVersion=23
     - targetSdkVersion=29
-    - toolsVersion=29.0.3
+    - toolsVersion=30.0.2
 
     # For the decryption of secrets needed to sign and publish our artifacts
     - secure: "LipL0wPv0uQrKitaeGxCpoQsx5sl/Pg/DtQv4S7Bi52DxfArgvD2hPB0TWgkgYGJPfENHLEyqg+H+/v2nON3IXY+cnsd+TW+P1T03/52D56ieSKGVtVtSYUOZUgoyxIIvRZWFh/UNg+AmZIjOCTJDLitBTUxD8kWux8NjhIqZow="

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jdk:
 env:
   global:
     # Remember to keep these four values in sync with values in the root build.gradle file
-    - compileSdkVersion=29
+    - compileSdkVersion=30
     - minSdkVersion=23
     - targetSdkVersion=29
     - toolsVersion=29.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,17 @@ ext {
   compileSdkVersion=30
   minSdkVersion=23
   targetSdkVersion=29
-  buildToolsVersion='29.0.3'
+  buildToolsVersion='30.0.2'
 
   // centrally manage some other dependencies
-  mapsforgeVersion = '0.13.0'
-  osmdroidVersion = '6.1.6'
+  mapsforgeVersion = '0.13.0' // TODO: 0.14.0 is available
+  osmdroidVersion = '6.1.6'   // TODO: 6.1.8 is available - test and remove our own implementation of https://github.com/osmdroid/osmdroid/issues/1578
 
   // test dependencies
-  assertjVersion = '3.15.0'
+  assertjVersion = '3.17.2'
   junitVersion = '4.13'
   mockitoVersion = '2.28.2'
-  robolectricVersion = '4.3.1'
+  robolectricVersion = '4.4'
 }
 
 // Configure common settings in all projects

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlinVersion = '1.4.0'
+  ext.kotlinVersion = '1.4.10'
   repositories {
     google()
     jcenter()
@@ -27,7 +27,7 @@ ext {
   // Android 4.2, 4.2.2  17  JELLY_BEAN_MR1
 
   // Remember to keep these values in sync with .travis.yml
-  compileSdkVersion=29
+  compileSdkVersion=30
   minSdkVersion=23
   targetSdkVersion=29
   buildToolsVersion='29.0.3'

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.triplet.play' version '2.7.5'
+  id 'com.github.triplet.play' version '2.8.1'
 }
 
 // Use a plugin to derive a version name (e.g. 3.7) and monotonically increasing version code (e.g. 1372)
@@ -79,8 +79,8 @@ play {
 dependencies {
   api project(':libraries:cyclestreets-fragments')
 
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-  androidTestImplementation 'androidx.test:rules:1.2.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+  androidTestImplementation 'androidx.test:rules:1.3.0'
   androidTestImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
 }

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -6,22 +6,22 @@ configurations {
 dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
-  implementation 'androidx.core:core:1.3.0'
+  implementation 'androidx.core:core:1.3.2'
   implementation 'androidx.preference:preference:1.1.1'
 
   api "org.osmdroid:osmdroid-android:${rootProject.ext.osmdroidVersion}"
   api 'org.slf4j:slf4j-android:1.7.30'
 
   // Retrofit for HTTP Client activities
-  api 'com.squareup.retrofit2:retrofit:2.8.1'
-  implementation 'com.squareup.retrofit2:converter-scalars:2.8.1'
-  implementation('com.squareup.retrofit2:converter-simplexml:2.8.1') {
+  api 'com.squareup.retrofit2:retrofit:2.9.0'
+  implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
+  implementation('com.squareup.retrofit2:converter-simplexml:2.9.0') {
     // Exclusions required as per https://github.com/square/retrofit/issues/1796
     exclude group: 'xpp3', module: 'xpp3'
     exclude group: 'stax', module: 'stax-api'
     exclude group: 'stax', module: 'stax'
   }
-  implementation 'com.squareup.retrofit2:converter-jackson:2.8.1'
+  implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
   implementation 'de.grundid.opendatalab:geojson-jackson:1.14'
 
   // XML / JSON conversion utilities
@@ -29,14 +29,11 @@ dependencies {
   implementation 'com.bazaarvoice.jolt:jolt-core:0.1.1'
   implementation 'com.bazaarvoice.jolt:json-utils:0.1.1'
 
-  testImplementation 'com.github.tomakehurst:wiremock-standalone:2.26.3'
+  testImplementation 'com.github.tomakehurst:wiremock-standalone:2.27.2'
   testImplementation "junit:junit:${rootProject.ext.junitVersion}"
   testImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
   testImplementation 'org.skyscreamer:jsonassert:1.5.0'
   testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoVersion}"
-  testImplementation("org.robolectric:robolectric:${rootProject.ext.robolectricVersion}") {
-    // https://github.com/robolectric/robolectric/issues/5245
-    exclude group: 'com.google.auto.service', module: 'auto-service'
-  }
-  testImplementation 'commons-io:commons-io:2.6'
+  testImplementation "org.robolectric:robolectric:${rootProject.ext.robolectricVersion}"
+  testImplementation 'commons-io:commons-io:2.8.0'
 }

--- a/libraries/cyclestreets-fragments/build.gradle
+++ b/libraries/cyclestreets-fragments/build.gradle
@@ -6,8 +6,5 @@ dependencies {
 
   testImplementation "junit:junit:${rootProject.ext.junitVersion}"
   testImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
-  testImplementation("org.robolectric:robolectric:${rootProject.ext.robolectricVersion}") {
-    // https://github.com/robolectric/robolectric/issues/5245
-    exclude group: 'com.google.auto.service', module: 'auto-service'
-  }
+  testImplementation "org.robolectric:robolectric:${rootProject.ext.robolectricVersion}"
 }

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -10,7 +10,7 @@ android {
 
 dependencies {
   api project(':libraries:cyclestreets-core')
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
   api "org.mapsforge:mapsforge-map-android:${rootProject.ext.mapsforgeVersion}"
   api "org.mapsforge:mapsforge-themes:${rootProject.ext.mapsforgeVersion}"
   // there is some suggestion (https://github.com/osmdroid/osmdroid/wiki/Mapsforge) that the below may be necessary
@@ -21,17 +21,15 @@ dependencies {
   implementation 'com.mikepenz:iconics-views:5.0.3@aar'
   api 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
 
-  api 'com.google.android.material:material:1.1.0'
-  api 'androidx.exifinterface:exifinterface:1.2.0'
+  api 'com.google.android.material:material:1.2.1'
+  api 'androidx.exifinterface:exifinterface:1.3.0'
   api 'androidx.preference:preference:1.1.1'
 
-  testImplementation 'androidx.test:core:1.2.0'
+  testImplementation 'androidx.test:core:1.3.0'
+  testImplementation 'androidx.test.ext:junit:1.1.2'
   testImplementation "junit:junit:${rootProject.ext.junitVersion}"
   testImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
   testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoVersion}"
-  testImplementation("org.robolectric:robolectric:${rootProject.ext.robolectricVersion}") {
-    // https://github.com/robolectric/robolectric/issues/5245
-    exclude group: 'com.google.auto.service', module: 'auto-service'
-  }
-  testImplementation 'commons-io:commons-io:2.6'
+  testImplementation "org.robolectric:robolectric:${rootProject.ext.robolectricVersion}"
+  testImplementation 'commons-io:commons-io:2.8.0'
 }

--- a/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/ReplanFromHereTest.kt
+++ b/libraries/cyclestreets-view/src/test/java/net/cyclestreets/liveride/ReplanFromHereTest.kt
@@ -3,6 +3,7 @@ package net.cyclestreets.liveride
 import android.content.Context
 import android.speech.tts.TextToSpeech
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.cyclestreets.CycleStreetsPreferences
 import net.cyclestreets.TestUtils
@@ -17,12 +18,20 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
 import org.osmdroid.util.GeoPoint
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLooper.shadowMainLooper
 
 
+/**
+ * The `shadowMainLooper().idle()` calls cause queued background async tasks to be run.
+ * Replanning is an async operation so that's why we call this after every replan we trigger.
+ *
+ * See http://robolectric.org/blog/2019/06/04/paused-looper/ for context.
+ */
+@LooperMode(LooperMode.Mode.PAUSED)
+@RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE, sdk = [28])
-@RunWith(RobolectricTestRunner::class)
 class ReplanFromHereTest {
 
     private lateinit var liveRideState: LiveRideState
@@ -51,11 +60,16 @@ class ReplanFromHereTest {
         val expectedWaypoints = doubleArrayOf(0.0, 52.0, 0.13140, 52.22105, 0.14744, 52.19962)
         val expectedJson = jsonFor(expectedWaypoints)
         `when`(mockApiClient.getJourneyJson("balanced", null, null, 20, expectedWaypoints)).thenReturn(expectedJson)
+
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(52.0, 0.0))
+        shadowMainLooper().idle()
+
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, expectedWaypoints)
 
         // Check multi-replans don't keep adding waypoints
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(53.0, 1.0))
+        shadowMainLooper().idle()
+
         val newExpectedWaypoints: DoubleArray = doubleArrayOf(1.0, 53.0, 0.13140, 52.22105, 0.14744, 52.19962)
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, newExpectedWaypoints)
     }
@@ -70,11 +84,16 @@ class ReplanFromHereTest {
         val expectedWaypoints: DoubleArray = doubleArrayOf(0.0, 52.0, 0.14744, 52.19962)
         val expectedJson = jsonFor(expectedWaypoints)
         `when`(mockApiClient.getJourneyJson("balanced", null, null, 20, expectedWaypoints)).thenReturn(expectedJson)
+
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(52.0, 0.0))
+        shadowMainLooper().idle()
+
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, expectedWaypoints)
 
         // Check multi-replans don't keep adding waypoints
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(53.0, 1.0))
+        shadowMainLooper().idle()
+
         val newExpectedWaypoints: DoubleArray = doubleArrayOf(1.0, 53.0, 0.14744, 52.19962)
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, newExpectedWaypoints)
     }
@@ -91,11 +110,16 @@ Journey time : 26 minutes""")
         val expectedWaypoints: DoubleArray = doubleArrayOf(0.0, 52.0, 0.11783, 52.20530, 0.13140, 52.22105, 0.14744, 52.19962)
         val expectedJson = jsonFor(expectedWaypoints)
         `when`(mockApiClient.getJourneyJson("balanced", null, null, 20, expectedWaypoints)).thenReturn(expectedJson)
+
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(52.0, 0.0))
+        shadowMainLooper().idle()
+
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, expectedWaypoints)
 
         // Check multi-replans don't keep adding waypoints
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(53.0, 1.0))
+        shadowMainLooper().idle()
+
         val newExpectedWaypoints: DoubleArray = doubleArrayOf(1.0, 53.0, 0.11783, 52.20530, 0.13140, 52.22105, 0.14744, 52.19962)
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, newExpectedWaypoints)
     }
@@ -110,11 +134,16 @@ Journey time : 26 minutes""")
         val expectedWaypoints: DoubleArray = doubleArrayOf(0.0, 52.0, 0.13140, 52.22105, 0.14744, 52.19962)
         val expectedJson = jsonFor(expectedWaypoints)
         `when`(mockApiClient.getJourneyJson("balanced", null, null, 20, expectedWaypoints)).thenReturn(expectedJson)
+
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(52.0, 0.0))
+        shadowMainLooper().idle()
+
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, expectedWaypoints)
 
         // Check multi-replans don't keep adding waypoints
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(53.0, 1.0))
+        shadowMainLooper().idle()
+
         val newExpectedWaypoints: DoubleArray = doubleArrayOf(1.0, 53.0, 0.13140, 52.22105, 0.14744, 52.19962)
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, newExpectedWaypoints)
     }
@@ -130,10 +159,14 @@ Journey time : 26 minutes""")
         val expectedJson = jsonFor(expectedWaypoints)
         `when`(mockApiClient.getJourneyJson("balanced", null, null, 20, expectedWaypoints)).thenReturn(expectedJson)
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(52.0, 0.0))
+        shadowMainLooper().idle()
+
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, expectedWaypoints)
 
         // Check multi-replans don't keep adding waypoints
         liveRideState = ReplanFromHere(liveRideState, GeoPoint(53.0, 1.0))
+        shadowMainLooper().idle()
+
         val newExpectedWaypoints: DoubleArray = doubleArrayOf(1.0, 53.0, 0.14744, 52.19962)
         verify(mockApiClient, times(1)).getJourneyJson("balanced", null, null, 20, newExpectedWaypoints)
     }


### PR DESCRIPTION
Based on https://developer.android.com/about/versions/11/behavior-changes-all I think this should be fine (we've already improved our approach around permissions in a relevant way).

Based on https://developer.android.com/about/versions/11/behavior-changes-11 I am **not** yet upgrading the target SDK - since I think the statement of:
> Scoped storage enforcement: Access into external storage directories is limited to an app-specific directory and specific types of media that the app has created.

has a potential impact until Jez's work on the offline mapping download has been completed.

@jezhiggins @mvl22 @HilaryN please review.