### PR TITLE
445: upgrade target SDK to 30 (Android 11)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
   // Remember to keep these values in sync with .travis.yml
   compileSdkVersion=30
   minSdkVersion=23
-  targetSdkVersion=29
+  targetSdkVersion=30
   buildToolsVersion='30.0.2'
 
   // centrally manage some other dependencies


### PR DESCRIPTION
Things seems to work OK in the emulator (both Android 10 and Android 11) with these changes in place.

Closes #445.