### PR TITLE
Added legacy storage flag

### DIFF
--- a/libraries/cyclestreets-view/src/main/AndroidManifest.xml
+++ b/libraries/cyclestreets-view/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-  <application android:supportsRtl="false">
+  <application
+      android:requestLegacyExternalStorage="true"
+      android:supportsRtl="false">
     <activity android:name="net.cyclestreets.AccountDetailsActivity"
               android:label="Account Details"
               android:windowSoftInputMode="stateVisible|adjustResize" />


### PR DESCRIPTION
The documentation says this is only valid for Android 10, but I've tested it on Android 11 and the exif permission still works on there (though it worked on there anyway without this change).
#448 
[Test legacy permissions flag.pdf](https://github.com/cyclestreets/android/files/5410922/Test.legacy.permissions.flag.pdf)

