### PR TITLE
Pause-resume issues / Move detach to onDestroy?

### DIFF
--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
@@ -108,6 +108,11 @@ open class CycleMapFragment : Fragment(), Undoable {
         map!!.onResume()
     }
 
+    override fun onDestroy() {
+        map!!.onDestroy()
+        super.onDestroy()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         if (map != null)
             map!!.onCreateOptionsMenu(menu)

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/MainNavDrawerActivity.kt
@@ -89,6 +89,11 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
         else if (CycleStreetsAppSupport.isNewVersion())
             onNewVersion()
         CycleStreetsAppSupport.splashScreenSeen()
+
+        val selectedItem = prefs().getInt(DRAWER_ITEMID_SELECTED_KEY, R.id.nav_journey_planner)
+        // If menu item not found, show journey planner
+        if (!showPage(selectedItem))
+            showPage(R.id.nav_journey_planner)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -184,9 +189,6 @@ abstract class MainNavDrawerActivity : AppCompatActivity(), OnNavigationItemSele
     }
 
     public override fun onResume() {
-        val selectedItem = prefs().getInt(DRAWER_ITEMID_SELECTED_KEY, R.id.nav_journey_planner)
-        if (!showPage(selectedItem))
-            showPage(R.id.nav_journey_planner)
         super.onResume()
         Route.registerListener(this)
         setBlogStateTitle()

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -180,9 +180,10 @@ public class CycleMapView extends FrameLayout
 
     // These lines effectively shut down the map.
     // This object needs to be discarded and re-created on resuming.
-    getTileProvider().detach();
-    getTileProvider().clearTileCache();
-    BitmapPool.getInstance().clearBitmapPool();
+    // Moved to onDestroy (todo remove commented out lines below)
+    //getTileProvider().detach();
+    //getTileProvider().clearTileCache();
+    //BitmapPool.getInstance().clearBitmapPool();
   }
 
   public void onResume() {
@@ -227,6 +228,11 @@ public class CycleMapView extends FrameLayout
     }.start();
   }
 
+  public void onDestroy() {
+    getTileProvider().detach();
+    //getTileProvider().clearTileCache(); todo not needed as this is in detach
+    BitmapPool.getInstance().clearBitmapPool();
+  }
   ////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////
   public void onCreateOptionsMenu(final Menu menu) {


### PR DESCRIPTION
I've been coming across a few niggly pause/resume issues (listed below).

What do you think about moving the _getTileProvider().detach()_ from onPause to onDestroy?  I'm worried about memory leaks if I do this?  I tried running it with LeakCanary but it didn't show any memory leak after I stopped the app.  On the other hand it also didn't show a memory leak when I took the detach out altogether so I'm confused there...

The code would need more work around the onResume / onPause but first I just wanted to ask what you thought about the general principle of moving the detach to onDestroy?

Here are some of the issues:

- Location Editor: map is lost when resuming after pausing, e.g. if permission request box comes up or if you go to the Home screen

- If in Itinerary or Blog when pausing, screen goes to journey planner (or most recent ?resumable? fragment) when resuming, rather than back to Itinerary or Blog.

- If Find a Place marker is showing when pausing, it would disappear when resuming except that I have put in a workaround to store it.  This means is stays there even if app destroyed – not so good.  I could refine the workaround further but I'd prefer to improve the pause/resume and get rid of this workaround.

- If POI bubble is displayed on journey planner, the bubble disappears when resuming.  It also disappears if you go to another screen (e.g. Itinerary) and back.

(I think waymarkers are stored so that they remain if app paused or destroyed.  I think that's good to keep them even when app destroyed.)

- When an item is selected from the Navigation Drawer (top left menu), a new instance of the fragment is created, meaning again that current state is lost (e.g. going from journey planner to Itinerary and back will mean that POI bubble disappears).

- If the permission request box comes up this also pauses the app.  I would like the app to continue straight to the requested action if permission is granted but this is made more difficult by the fact that the fragment is destroyed and re-created when the app resumes.