### PR TITLE
461: fix tile loading regression bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 
 ext {
   // From e.g. https://source.android.com/setup/start/build-numbers
+  // Android 11          30  R
   // Android 10          29  Q
   // Android 9.0         28  PIE
   // Android 8.1         27  OREO_MR1

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -13,8 +13,8 @@ apply plugin: 'me.moallemi.advanced-build-version'
 advancedVersioning {
   nameOptions {
     versionMajor 3
-    versionMinor 10
-    versionPatch 0
+    versionMinor 9
+    versionPatch 1
   }
   codeOptions {
     versionCodeType 'GIT_COMMIT_COUNT'

--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -5,7 +5,7 @@
      <li>Work in progress: upgrading the offline map integration; offline maps may not work properly for a few beta releases. Sign up as a <a href='https://play.google.com/store/apps/details?id=net.cyclestreets.maps.uk'>Beta tester of the Map Pack</a> to get the latest map.</li>
   -->
 
-<h3>Release 3.10 (Beta)</h3>
+<!--<h3>Release 3.10 (Beta)</h3>-->
 <!--<strong>Features:</strong>-->
 <!--<ul>-->
 <!--  <li>Circular leisure routes! Tap your starting waypoint and then choose a distance.</li>-->
@@ -14,6 +14,12 @@
 <!--<ul>-->
 <!--  <li>Various minor bug fixes.</li>-->
 <!--</ul>-->
+
+<h3>Release 3.9.1</h3>
+<strong>Bug fixes:</strong>
+<ul>
+  <li>Fix an issue with downloading map tiles.</li>
+</ul>
 
 <h3>Release 3.9</h3>
 <strong>Features:</strong>

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,1 +1,7 @@
+LiveRide now shows remaining distance and optionally remaining time and/or ETA.
+POI URLs (e.g. bike shop websites) now appear as clickable links.
+Find a Place now puts a marker on the screen instead of just centering the map.
 
+Various minor bug fixes (incl. downloading map tiles).
+
+Please note that the Offline Vector maps support (using the separate "Cyclestreets UK Map Pack" app bundle) has been broken by Android platform changes.  We aim to restore this functionality in a subsequent release.

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
@@ -2,6 +2,6 @@ LiveRide now shows remaining distance and optionally remaining time and/or ETA.
 POI URLs (e.g. bike shop websites) now appear as clickable links.
 Find a Place now puts a marker on the screen instead of just centering the map.
 
-Various minor bug fixes.
+Various minor bug fixes (incl. downloading map tiles).
 
 Please note that the Offline Vector maps support (using the separate "Cyclestreets UK Map Pack" app bundle) has been broken by Android platform changes.  We aim to restore this functionality in a subsequent release.

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleStreetsAppSupport.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleStreetsAppSupport.java
@@ -2,15 +2,23 @@ package net.cyclestreets;
 
 import net.cyclestreets.api.ApiClient;
 import net.cyclestreets.routing.Route;
+import net.cyclestreets.util.Logging;
 import net.cyclestreets.util.TurnIcons;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
 public final class CycleStreetsAppSupport {
-  private static boolean isFirstRun_;
-  private static boolean isNew_;
-  private static String version_;
+
+  private static final String TAG = Logging.getTag(CycleStreetsAppSupport.class);
+
+  private static boolean isFirstRun;
+  private static boolean isNew;
+  private static String version;
+  private static Integer versionCode;
+  private static String previousVersion;
+  private static Integer previousVersionCode;
 
   public static void initialise(final Context context, final int prefsDefault) {
     TurnIcons.initialise(context);
@@ -21,32 +29,40 @@ public final class CycleStreetsAppSupport {
     ApiClient.INSTANCE.initialise(context);
     BlogState.INSTANCE.initialise(context);
 
-    version_ = version(context);
+    version = version(context);
+    versionCode = code(version);
+    previousVersion = previousVersion(context);
+    previousVersionCode = code(previousVersion);
 
-    isFirstRun_ = isFirstRun(context);
-    isNew_ = isNew(context, version_);
+    isFirstRun = isFirstRun(context);
+    isNew = !version.equals(previousVersion);
 
-    saveVersion(context, version_);
+    saveVersion(context, version);
+
+    migratePreferences(previousVersionCode, versionCode);
   }
 
-  public static String version() { return version_; }
-  public static boolean isNewVersion() { return isNew_; }
-  public static boolean isFirstRun() { return isFirstRun_; }
+  public static String version() { return version; }
+  public static boolean isNewVersion() { return isNew; }
+  public static boolean isFirstRun() { return isFirstRun; }
   public static void splashScreenSeen() {
-    isFirstRun_ = false;
-    isNew_ = false;
+    isFirstRun = false;
+    isNew = false;
   }
 
   private static String version(final Context context) {
     return "Version : " + AppInfo.INSTANCE.version(context);
   }
+  private static Integer code(String versionString) {
+    if (UNKNOWN.equals(versionString)) {
+      return 0;
+    }
+    String[] split = versionString.split("/");
+    return Integer.valueOf(split[split.length - 1]);
+  }
 
   private static boolean isFirstRun(final Context context) {
     return UNKNOWN.equals(previousVersion(context));
-  }
-  private static boolean isNew(final Context context, final String version) {
-    String prev = previousVersion(context);
-    return !version.equals(prev);
   }
   private static String previousVersion(final Context context) {
     return prefs(context).getString(VERSION_KEY, UNKNOWN);
@@ -66,6 +82,15 @@ public final class CycleStreetsAppSupport {
 
   private static final String VERSION_KEY = "previous-version";
   private static final String UNKNOWN = "unknown";
+
+  private static void migratePreferences(Integer previousVersionCode, Integer versionCode) {
+    Log.i(TAG, "Upgrading from " + previousVersion + " (" + previousVersionCode + ") to " + version + " (" + versionCode + ")");
+
+    if (previousVersionCode < 1621 && versionCode >= 1621) {
+      Log.i(TAG, "Clearing OSMDroid cache location after upgrade to target Android 10 (SDK 29) or higher changed accessible paths");
+      CycleStreetsPreferences.clearOsmdroidCacheLocation();
+    }
+  }
 
   private CycleStreetsAppSupport() { }
 }


### PR DESCRIPTION
Fixes #461.

I've tested this works locally, on my real phone, reproducing and fixing as follows: (relevant logs inlined for each stage)
- installing 3.8.1 fresh
   ```
   I/views.CycleMapView: Creating map view. App has write-external permission? false; osmdroid base path: /data/user/0/net.cyclestreets/files/osmdroid; osmdroid tile cache location: /data/user/0/net.cyclestreets/files/osmdroid/tiles
   ```
- approving permissions
   ```
   I/views.CycleMapView: Creating map view. App has write-external permission? true; osmdroid base path: /storage/emulated/0/osmdroid; osmdroid tile cache location: /storage/emulated/0/osmdroid/tiles
   ```
- upgrading to 3.9, map tile downloads stop working
   ```
   I/views.CycleMapView: Creating map view. App has write-external permission? true; osmdroid base path: /storage/emulated/0/osmdroid; osmdroid tile cache location: /storage/emulated/0/osmdroid/tiles
   E/BitmapFactory: Unable to decode stream: java.io.FileNotFoundException: /storage/emulated/0/osmdroid/tiles/CycleStreets-OSM/14/8190/5448@2x.png.tile: open failed: EACCES (Permission denied)
   ... repeat the above error log for a number of map tiles, ad infinitum
   ```
- upgrading to 3.9.1, map tile downloads work again
   ```
   I/CycleStreetsAppSupport: Upgrading from Version : net.cyclestreets/3.9.0/1618 (1618) to Version : net.cyclestreets/3.9.1/1621 (1621)
   I/CycleStreetsAppSupport: Clearing OSMDroid cache location after upgrade to target Android 10 (SDK 29) or higher changed accessible paths
   I/views.CycleMapView: Creating map view. App has write-external permission? true; osmdroid base path: /data/user/0/net.cyclestreets/files/osmdroid; osmdroid tile cache location: /data/user/0/net.cyclestreets/files/osmdroid/tiles
   ```