### PR TITLE
Revert to mikepenz iconics 5.0.3 as icons disappear with 5.2.8

### DIFF
--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -16,10 +16,10 @@ dependencies {
   api "org.mapsforge:mapsforge-themes:${rootProject.ext.mapsforgeVersion}"
   // there is some suggestion (https://github.com/osmdroid/osmdroid/wiki/Mapsforge) that the below may be necessary
 //  api "org.osmdroid:osmdroid-mapsforge:${rootProject.ext.osmdroidVersion}@aar"
-
-  api 'com.mikepenz:iconics-core:5.2.8@aar'
-  api 'com.mikepenz:iconics-typeface-api:5.2.8@aar'
-  implementation 'com.mikepenz:iconics-views:5.2.8@aar'
+// Icons disappear with 5.2.8 so reverting to 5.0.3 for now
+  api 'com.mikepenz:iconics-core:5.0.3@aar'
+  api 'com.mikepenz:iconics-typeface-api:5.0.3@aar'
+  implementation 'com.mikepenz:iconics-views:5.0.3@aar'
   api 'com.mikepenz:google-material-typeface:3.0.1.6.original-kotlin@aar'
 
   api 'com.google.android.material:material:1.3.0'


### PR DESCRIPTION
I've not had chance to look into this, so maybe revert to 5.0.3 for now?

Fixes #471 