### PR TITLE
Circular Route POIs

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/JourneyPlanner.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/JourneyPlanner.java
@@ -17,8 +17,8 @@ public class JourneyPlanner {
   public static String getCircularJourneyJson(final Waypoints waypoints,
                                               final Integer distance,
                                               final Integer duration,
-                                              final String pois) {
-    return ApiClient.INSTANCE.getCircularJourneyJson(lonLat(waypoints), distance, duration, pois);
+                                              final String poiTypes) {
+    return ApiClient.INSTANCE.getCircularJourneyJson(lonLat(waypoints), distance, duration, poiTypes);
   }
 
   public static String retrievePreviousJourneyJson(final String plan,

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POI.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POI.java
@@ -33,7 +33,7 @@ public class POI
     pos = new GeoPoint(lat, lon);
   }
 
-  void setCategory(final POICategory category) { this.category = category; }
+  public void setCategory(final POICategory category) { this.category = category; }
 
   public int id() { return id; }
   public String name() { return stringOrBlank(name); }

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POICategory.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/POICategory.kt
@@ -4,7 +4,7 @@ import android.graphics.drawable.Drawable
 import net.cyclestreets.api.ApiClient.getPOIs
 import org.osmdroid.api.IGeoPoint
 
-class POICategory(private val key: String,
+class POICategory(val key: String,
                   val name: String,
                   val icon: Drawable) {
 

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/JourneyStringTransformer.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/JourneyStringTransformer.kt
@@ -44,13 +44,29 @@ private const val V1API_XML_JOLT_SPEC = """[{
   }
 }]
 """
-
-private const val V1API_JSON_JOLT_SPEC = """[{
+// For A-B route, input json will have array of waypoints.
+// For circular route, input json has a single waypoint.
+// For circular routes it may also have a single poi or an array of pois (or none at all).
+// Convert these to arrays, do the transformation, then convert back to arrays if single
+// Note (if debugging) that the waypoints in the output may appear at the beginning or in the original place,
+// depending on whether they are an array of waypoints (A-B route) or a single item (circular route).
+private const val V1API_JSON_JOLT_SPEC = """
+[// First, convert single waypoint / poi to array
+{
+    "operation": "cardinality",
+    "spec": {
+    "waypoint": "MANY",
+    "poi": "MANY"
+    }
+},
+// Now do the transformation, but note that 1-element arrays will get converted back to strings...
+{
   "operation": "shift",
   "spec": {
+    
     "waypoint": {
-      "*": { "\\@attributes": "waypoints" }
-    },
+      "*": { "\\@attributes": "waypoints" }},
+    
     "marker": {
       "*": {
         "\\@attributes": {
@@ -61,6 +77,19 @@ private const val V1API_JSON_JOLT_SPEC = """[{
         }
       }
     },
+    "poi": {
+      "*": { "\\@attributes": "pois" }
+    },
+   
     "error": "Error"
   }
-}]"""
+},
+// ... so we need to convert the strings back to arrays!
+{
+    "operation": "cardinality",
+    "spec": {
+    "waypoints": "MANY",
+    "pois": "MANY"
+    }
+}
+]"""

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/RetrofitApiClient.java
@@ -157,8 +157,8 @@ public class RetrofitApiClient {
   public String getCircularJourneyJson(final String itineraryPoints,
                                        final Integer distance,
                                        final Integer duration,
-                                       final String poitypes) throws IOException {
-    Response<String> response = v1Api.getCircularJourneyJson(PLAN_LEISURE, itineraryPoints, distance, duration, poitypes, REPORT_ERRORS).execute();
+                                       final String poiTypes) throws IOException {
+    Response<String> response = v1Api.getCircularJourneyJson(PLAN_LEISURE, itineraryPoints, distance, duration, poiTypes, REPORT_ERRORS).execute();
     return JourneyStringTransformerKt.fromV1ApiJson(response.body());
   }
 

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/dto/PoiTypesDto.kt
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/api/client/dto/PoiTypesDto.kt
@@ -42,7 +42,7 @@ class PoiTypesDto {
 }
 
 
-private fun poiIcon(context: Context, id: String): Drawable {
+fun poiIcon(context: Context, id: String): Drawable {
     val key = "poi_${id}"
     val res = context.resources
     val resPackage = res.getResourcePackageName(defaultResId)

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/RouteMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/RouteMapFragment.kt
@@ -40,6 +40,7 @@ class RouteMapFragment : CycleMapFragment(), Route.Listener {
 
         overlayPushBottom(RouteHighlightOverlay(requireContext(), mapView()))
         overlayPushBottom(POIOverlay(mapView()))
+        overlayPushBottom(CircularRoutePOIOverlay(mapView()))
         overlayPushBottom(RouteOverlay())
 
         routeSetter = TapToRouteOverlay(mapView(), this)
@@ -110,7 +111,7 @@ class RouteMapFragment : CycleMapFragment(), Route.Listener {
                 Route.plotCircularRoute(RoutePlans.PLAN_LEISURE,
                                         if (distance != 0) distance else null,
                                         if (duration != 0) duration else null,
-                                   null,
+                                        data.getStringExtra(EXTRA_CIRCULAR_ROUTE_POI_CATEGORIES),
                                         requireContext())
             }
         }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/CycleStreetsConstants.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/CycleStreetsConstants.kt
@@ -28,6 +28,7 @@ const val EXTRA_ROUTE_SPEED = "net.cyclestreets.extra.ROUTE_SPEED"
 const val EXTRA_ROUTE_NUMBER = "net.cyclestreets.extra.ROUTE"
 const val EXTRA_CIRCULAR_ROUTE_DISTANCE = "net.cyclestreets.extra.CIRCULAR_ROUTE_DISTANCE"
 const val EXTRA_CIRCULAR_ROUTE_DURATION = "net.cyclestreets.extra.CIRCULAR_ROUTE_DURATION"
+const val EXTRA_CIRCULAR_ROUTE_POI_CATEGORIES = "net.cyclestreets.extra.CIRCULAR_ROUTE_POI_CATEGORIES"
 const val ROUTE_ID = "net.cyclestreets.extra.ROUTE_ID"
 
 // Permission request codes

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/CycleStreetsRoutingTask.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/CycleStreetsRoutingTask.kt
@@ -10,7 +10,7 @@ internal open class CycleStreetsRoutingTask(private val routeType: String,
                                             context: Context,
                                             private val distance: Int? = null,
                                             private val duration: Int? = null,
-                                            private val pois: String? = null) : RoutingTask<Waypoints>(R.string.route_finding_new, context) {
+                                            private val poiTypes: String? = null) : RoutingTask<Waypoints>(R.string.route_finding_new, context) {
     override fun doInBackground(vararg waypoints: Waypoints): RouteData? {
         val wp = waypoints[0]
         return fetchRoute(routeType,
@@ -18,6 +18,6 @@ internal open class CycleStreetsRoutingTask(private val routeType: String,
                           waypoints = wp,
                           distance = distance,
                           duration = duration,
-                          pois = pois)
+                          poiTypes = poiTypes)
     }
 }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
@@ -44,9 +44,9 @@ object Route {
     fun plotCircularRoute(plan: String,
                           distance: Int?,
                           duration: Int?,
-                          pois: String?,
+                          poiTypes: String?,
                           context: Context) {
-        val query = CycleStreetsRoutingTask(plan, 0, context, distance, duration, pois)
+        val query = CycleStreetsRoutingTask(plan, 0, context, distance, duration, poiTypes)
         query.execute(waypoints_)
     }
 
@@ -150,7 +150,7 @@ object Route {
             clearRouteLoaded()
             return
         }
-        plannedRoute_ = loadFromJson(route.json(), route.points(), route.name())
+        plannedRoute_ = loadFromJson(route.json(), route.points(), route.name(), context_)
         db_.saveRoute(plannedRoute_, route.json())
         waypoints_ = plannedRoute_.waypoints
         listeners_.onNewJourney(plannedRoute_, waypoints_)

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/RoutingTask.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/RoutingTask.kt
@@ -30,9 +30,9 @@ abstract class RoutingTask<Params> protected constructor(private val initialMsg:
                              waypoints: Waypoints? = null,
                              distance: Int? = null,
                              duration: Int? = null,
-                             pois: String? = null): RouteData? {
+                             poiTypes: String? = null): RouteData? {
         return try {
-            val json = doFetchRoute(routeType, itinerary, speed, waypoints, distance, duration, pois)
+            val json = doFetchRoute(routeType, itinerary, speed, waypoints, distance, duration, poiTypes)
 
             when {
                 (json == "null") -> {
@@ -61,10 +61,10 @@ abstract class RoutingTask<Params> protected constructor(private val initialMsg:
                              waypoints: Waypoints?,
                              distance: Int?,
                              duration: Int?,
-                             pois: String?): String {
+                             poiTypes: String?): String {
         return when {
             itinerary != NO_ITINERARY -> getRoutebyItineraryNo(routeType, itinerary)
-            routeType == PLAN_LEISURE -> JourneyPlanner.getCircularJourneyJson(waypoints, distance, duration, pois)
+            routeType == PLAN_LEISURE -> JourneyPlanner.getCircularJourneyJson(waypoints, distance, duration, poiTypes)
             else -> JourneyPlanner.getJourneyJson(routeType, speed, waypoints!!)
         }
     }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/JourneyDomainObject.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/JourneyDomainObject.java
@@ -14,6 +14,8 @@ public class JourneyDomainObject {
   public final RouteDomainObject route = new RouteDomainObject();
   @JsonProperty
   public final List<SegmentDomainObject> segments = new ArrayList<>();
+  @JsonProperty
+  public final List<PoiDomainObject> pois = new ArrayList<>();
 
   @Override
   public String toString() {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/PoiDomainObject.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/PoiDomainObject.kt
@@ -1,0 +1,18 @@
+package net.cyclestreets.routing.domain
+
+import com.fasterxml.jackson.annotation.JsonProperty
+// Used for circular routes
+class PoiDomainObject {
+    @JsonProperty
+    val poitypeId: String? = null
+    @JsonProperty
+    val name: String? = null
+    @JsonProperty
+    val website: String? = null
+    @JsonProperty
+    val longitude: Float = 0.0F
+    @JsonProperty
+    val latitude: Float = 0.0F
+    @JsonProperty
+    val sequenceId: Short = 0
+}

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/RouteDomainObject.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/domain/RouteDomainObject.java
@@ -18,10 +18,6 @@ public final class RouteDomainObject {
   @JsonProperty
   public String finish;
   @JsonProperty
-  public double start_longitude;
-  @JsonProperty
-  public double start_latitude;
-  @JsonProperty
   public String otherRoutes;
 
   @Override

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CircularRouteViewModel.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CircularRouteViewModel.kt
@@ -2,6 +2,7 @@ package net.cyclestreets.views
 
 import androidx.lifecycle.ViewModel
 import net.cyclestreets.*
+import net.cyclestreets.api.POICategory
 import java.util.*
 
 class CircularRouteViewModel: ViewModel() {
@@ -17,6 +18,7 @@ class CircularRouteViewModel: ViewModel() {
     // mutable by the user
     var currentTab = DURATION
     var values = arrayOf(CIRCULAR_ROUTE_MIN_MINUTES, CIRCULAR_ROUTE_MIN_DISTANCE)
+    var activeCategories: List<POICategory> = ArrayList()
 
     fun durationInSeconds(): Int {
         return values[DURATION] * 60

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -58,7 +58,7 @@ public class CycleMapView extends FrameLayout
   private MapView mapView_;
   private ITileSource renderer_;
   private final SharedPreferences prefs_;
-  private final ControllerOverlay controllerOverlay_;
+  public final ControllerOverlay controllerOverlay_;
   private final LocationOverlay location_;
   private final FindPlaceOverlay findPlaceOverlay_;
   private final int overlayBottomIndex_;

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/Bubble.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/Bubble.kt
@@ -1,0 +1,122 @@
+package net.cyclestreets.views.overlay
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.*
+import android.net.Uri
+import android.view.MotionEvent
+import android.webkit.URLUtil
+import androidx.core.content.ContextCompat
+import net.cyclestreets.util.Draw
+import org.osmdroid.api.IProjection
+import org.osmdroid.views.MapView
+import net.cyclestreets.Undoable
+import net.cyclestreets.view.R
+import net.cyclestreets.views.CycleMapView
+import org.osmdroid.views.Projection
+
+object Bubble {
+    var activeItem: POIOverlay.POIOverlayItem? = null
+    private var bubble: Rect? = null
+    private val curScreenCoords = Point()
+    private lateinit var tapHereText: String
+    private lateinit var controller: ControllerOverlay
+
+    fun initialise(context: Context, mapView: CycleMapView) {
+        controller = mapView.controllerOverlay_
+        tapHereText = context.getString(R.string.tap_here)
+    }
+
+    fun onSingleTap(event: MotionEvent, pj: Projection, context: Context, overlay: Undoable): Boolean {
+        if (activeItem != null && tappedInBubble(event, pj, context, overlay))
+            return true
+        return false
+    }
+
+    private fun tappedInBubble(event: MotionEvent, pj: Projection, context: Context, overlay: Undoable): Boolean {
+        val screenRect = pj.intrinsicScreenRect
+        val eventX = screenRect.left + event.x.toInt()
+        val eventY = screenRect.top + event.y.toInt()
+
+        if (!bubble!!.contains(eventX, eventY))
+            return false
+        // Check if tapped on link
+        if (eventY < Draw.titleSectionY) {
+            showWebpage(activeItem, context)
+        }
+
+        hideBubble(overlay)
+        return true
+    }
+
+    private fun showWebpage(item: POIOverlay.POIOverlayItem?, context: Context) {
+        val url = item!!.poi.url()
+
+        if (url != "") {
+            val webpage = Uri.parse(url)
+            val intent = Intent(Intent.ACTION_VIEW, webpage)
+
+            if (intent.resolveActivity(context.getPackageManager()) != null) {
+                ContextCompat.startActivity(context, intent, null)
+            }
+        }
+    }
+
+    fun hideOrShowBubble(item: POIOverlay.POIOverlayItem?, overlay: Undoable) {
+        if (activeItem === item)
+            hideBubble(overlay)
+        else
+            showBubble(item!!, overlay)
+    }
+
+    fun showBubble(item: POIOverlay.POIOverlayItem, overlay: Undoable) {
+        hideBubble(overlay)
+        activeItem = item
+        controller.pushUndo(overlay)
+    }
+
+    fun hideBubble(overlay: Undoable) {
+        activeItem = null
+        controller.flushUndo(overlay)
+    }
+
+    fun drawBubble(canvas: Canvas, mapView: MapView, textBrush: Paint, urlBrush: Paint, offset: Int) {
+        var url = activeItem!!.poi.url()
+        url = if (URLUtil.isValidUrl(url)) url else ""
+        val title = if (activeItem!!.title.isNullOrEmpty() && (activeItem!!.poi.url().isNotBlank())) tapHereText else activeItem!!.title
+
+        val bubbleText = listOf(
+                title,
+                activeItem!!.snippet,
+                activeItem!!.poi.phone(),
+                activeItem!!.poi.openingHours()
+        ).filterNot { it.isNullOrBlank() }.joinToString("\n")
+
+        // find the right place
+        val pj: IProjection = mapView.projection
+        pj.toPixels(activeItem!!.point, curScreenCoords)
+
+        val x = curScreenCoords.x
+        val y = curScreenCoords.y
+
+        val matrix = mapView.matrix
+        val matrixValues = FloatArray(9)
+        matrix.getValues(matrixValues)
+
+        val scaleX = Math.sqrt(matrixValues[Matrix.MSCALE_X]
+                * matrixValues[Matrix.MSCALE_X] + matrixValues[Matrix.MSKEW_Y]
+                * matrixValues[Matrix.MSKEW_Y].toDouble()).toFloat()
+        val scaleY = Math.sqrt(matrixValues[Matrix.MSCALE_Y]
+                * matrixValues[Matrix.MSCALE_Y] + matrixValues[Matrix.MSKEW_X]
+                * matrixValues[Matrix.MSKEW_X].toDouble()).toFloat()
+
+        canvas.save()
+        canvas.rotate(-mapView.mapOrientation, x.toFloat(), y.toFloat())
+        canvas.scale(1 / scaleX, 1 / scaleY, x.toFloat(), y.toFloat())
+
+        bubble = Draw.drawBubble(canvas, textBrush, urlBrush, offset, cornerRadius(), curScreenCoords, bubbleText, url, title)
+
+        canvas.restore()
+    }
+
+}

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/CircularRoutePOIOverlay.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/CircularRoutePOIOverlay.kt
@@ -1,0 +1,83 @@
+package net.cyclestreets.views.overlay
+
+import android.content.SharedPreferences
+import net.cyclestreets.Undoable
+import net.cyclestreets.routing.Journey
+import net.cyclestreets.routing.Route
+import net.cyclestreets.routing.Waypoints
+import net.cyclestreets.util.Logging
+import net.cyclestreets.views.CycleMapView
+import org.osmdroid.api.IGeoPoint
+import org.osmdroid.events.ScrollEvent
+import org.osmdroid.events.ZoomEvent
+import org.osmdroid.util.BoundingBox
+
+
+private val TAG = Logging.getTag(CircularRoutePOIOverlay::class.java)
+
+class CircularRoutePOIOverlay(mapView: CycleMapView): PauseResumeListener, Route.Listener,
+        LiveItemOverlay<POIOverlay.POIOverlayItem?>(mapView, false), Undoable {
+
+    private var currentJourney: Journey? = null
+
+    override fun onResume(prefs: SharedPreferences) {
+        Route.registerListener(this)
+    }
+
+    override fun onPause(prefs: SharedPreferences.Editor) {
+        Route.unregisterListener(this)
+    }
+
+    override fun onNewJourney(journey: Journey, waypoints: Waypoints) {
+            removePois()
+            currentJourney = journey
+            val items: MutableList<POIOverlay.POIOverlayItem> = ArrayList()
+            for (poi in currentJourney!!.circularRoutePois) {
+                items.add(POIOverlay.POIOverlayItem(poi))
+            }
+            setItems(items as List<POIOverlay.POIOverlayItem?>?)
+    }
+
+    override fun onResetJourney() {
+        removePois()
+    }
+
+    private fun removePois() {
+        Bubble.hideBubble(this)
+        // Remove Circular Route POI's from display
+        if (currentJourney != null) {
+            items().clear()
+            currentJourney = null
+        }
+    }
+
+    // This won't ever be called
+    override fun fetchItemsInBackground(mapCentre: IGeoPoint,
+                                        zoom: Int,
+                                        boundingBox: BoundingBox): Boolean {
+        // Return false so that "Loading" message doesn't appear
+        return false
+    }
+
+    override fun onZoom(event: ZoomEvent): Boolean {
+        // Don't want any of the functionality in the superclass so override and do nothing / return true
+        return true
+    }
+
+    override fun onScroll(event: ScrollEvent): Boolean {
+        // Don't want any of the functionality in the superclass, so override and do nothing / return true
+        return true
+    }
+
+    override fun onItemSingleTap(item: POIOverlay.POIOverlayItem?): Boolean {
+        Bubble.hideOrShowBubble(item, this)
+        redraw()
+        return true
+    }
+
+    override fun onBackPressed(): Boolean {
+        Bubble.hideBubble(this)
+        redraw()
+        return true
+    }
+}

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/LiveItemOverlay.java
@@ -102,7 +102,7 @@ public abstract class LiveItemOverlay<T extends OverlayItem>
 
   @Override
   public boolean onZoom(final ZoomEvent event) {
-    if (event.getZoomLevel() < zoomLevel_)
+    if (event.getZoomLevel() < zoomLevel_)  // Zoomed out
       items().clear();
     zoomLevel_ = (int)event.getZoomLevel();
     refreshItems();

--- a/libraries/cyclestreets-view/src/main/res/layout/activity_circular_route.xml
+++ b/libraries/cyclestreets-view/src/main/res/layout/activity_circular_route.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingBottom="48dp"
     tools:context="net.cyclestreets.views.CircularRouteActivity">
 
     <TextView
@@ -16,25 +15,22 @@
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/create_circular_route_desc"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+        android:textAppearance="@style/CircularRouteTextSize" />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/circularRouteDurationOrDistanceTab"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/circularRouteHeader"
-        android:layout_marginTop="16dp"
-
+        android:layout_marginBottom="@dimen/CRmargin"
         android:paddingStart="8dp"
-        android:paddingTop="8dp"
         android:paddingEnd="8dp"
-        android:paddingBottom="8dp"
         app:tabGravity="fill"
         app:tabIndicatorColor="@color/apptheme_color"
         app:tabIndicatorHeight="4dp"
         app:tabMaxWidth="0dp"
         app:tabSelectedTextColor="@color/apptheme_color"
-        app:tabTextAppearance="@style/TextAppearance.AppCompat.Large"
+        app:tabTextAppearance="@style/CircularRouteTextSize"
         app:tabTextColor="@color/cs_primary_dark_material_light">
 
         <com.google.android.material.tabs.TabItem
@@ -60,8 +56,7 @@
         android:layout_alignParentLeft="true"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large"
-        android:textColor="@color/cs_primary_dark_material_light" />
+        android:textAppearance="@style/CircularRouteTextSize" />
 
     <TextView
         android:id="@+id/circularRouteSeekBarMax"
@@ -70,15 +65,13 @@
         android:layout_below="@id/circularRouteDurationOrDistanceTab"
         android:layout_alignParentRight="true"
         android:paddingRight="16dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large"
-        android:textColor="@color/cs_primary_dark_material_light" />
+        android:textAppearance="@style/CircularRouteTextSize" />
 
     <SeekBar
         android:id="@+id/circularRouteSeekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/circularRouteSeekBarMin"
-        android:layout_marginTop="8dp"
         android:max="240" />
 
 
@@ -89,7 +82,8 @@
         android:layout_below="@id/circularRouteSeekBar"
         android:layout_centerInParent="false"
         android:layout_centerHorizontal="true"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+        android:layout_marginBottom="@dimen/CRmargin"
+        android:textAppearance="@style/CircularRouteTextSize" />
 
     <Button
         android:id="@+id/circularRouteGoButton"
@@ -97,13 +91,56 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_marginStart="48dp"
-        android:layout_marginTop="24dp"
         android:layout_marginEnd="48dp"
         android:backgroundTint="@color/apptheme_color"
         android:onClick="circularRouteGoButtonClick"
         android:text="@string/create_circular_route_button"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+        android:textAppearance="@style/CircularRouteTextSize"
         android:textColor="@color/cs_white" />
 
+    <TextView
+        android:id="@+id/poiHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/circularRouteCurrentValue"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
+        android:gravity="center"
+        android:text="@string/choose_pois_to_route_via"
+        android:textAppearance="@style/CircularRouteTextSize" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/poiHeader"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/circularRoutePoiTextView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="48dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="@string/num_poitypes_selected"
+            android:textAlignment="center"
+            android:textAppearance="@style/CircularRouteTextSize" />
+
+        <Button
+            android:id="@+id/poiButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="48dp"
+            android:layout_weight="1"
+            android:backgroundTint="@color/apptheme_color"
+            android:onClick="poiButtonOnClick"
+            android:text="@string/pois"
+            android:textAppearance="@style/CircularRouteTextSize"
+            android:textColor="@color/cs_white" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/libraries/cyclestreets-view/src/main/res/values-de/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-de/strings.xml
@@ -122,4 +122,13 @@
   <string name="remaining">Verbleibende</string>
   <string name="slash_ETA">/ Ankunft</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-es/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-es/strings.xml
@@ -121,4 +121,13 @@
   <string name="remaining">Restante</string>
   <string name="slash_ETA">/ Llegada</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-fr/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-fr/strings.xml
@@ -122,4 +122,13 @@
   <string name="remaining">Restant</string>
   <string name="slash_ETA">/ Arr. à</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-it/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-it/strings.xml
@@ -120,4 +120,13 @@
   <string name="remaining">Rimanente</string>
   <string name="slash_ETA">/ Arrivo</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-land/styles.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-land/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- In order to fit everything in on the Nexus One landscape mode, we need a smaller text size... -->
+    <style name="CircularRouteTextSize" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <item name="android:textSize">15sp</item>
+    </style>
+    <!-- ... and less space between views -->
+    <dimen name="CRmargin">0dp</dimen>
+</resources>

--- a/libraries/cyclestreets-view/src/main/res/values-port/styles.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-port/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- In portrait mode there is more space for larger text size -->
+    <style name="CircularRouteTextSize" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <item name="android:textSize">18sp</item>
+    </style>
+</resources>

--- a/libraries/cyclestreets-view/src/main/res/values-pt/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-pt/strings.xml
@@ -121,4 +121,13 @@
   <string name="remaining">Restante</string>
   <string name="slash_ETA">/ Chegada</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-ru/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-ru/strings.xml
@@ -122,4 +122,13 @@
   <string name="remaining">Остаток</string>
   <string name="slash_ETA">/ прибытие</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values-tr/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values-tr/strings.xml
@@ -120,4 +120,13 @@
   <string name="remaining">Remaining</string>
   <string name="slash_ETA">/ ETA</string>
 
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -183,11 +183,13 @@
   <string name="remaining">Remaining</string>
   <string name="slash_ETA">/ ETA</string>
 
-  <string name="duration" translatable="false">Duration</string>
-  <string name="distance" translatable="false">Distance</string>
-  <string name="circular_route" translatable="false">Circular Route</string>
-  <string name="create_circular_route_desc" translatable="false">Create a circular route based on a duration or distance</string>
-  <string name="create_circular_route_button" translatable="false">Create circular route</string>
-  <string name="mins" translatable="false">mins</string>
-
+  <string name="duration">Duration</string>
+  <string name="distance">Distance</string>
+  <string name="circular_route">Circular Route</string>
+  <string name="create_circular_route_desc">Create a circular route based on a duration or distance</string>
+  <string name="create_circular_route_button">Create circular route</string>
+  <string name="mins">mins</string>
+  <string name="choose_pois_to_route_via">Optionally, choose Points of Interest to route via:</string>
+  <string name="pois">POIs</string>
+  <string name="num_poitypes_selected">%1$s selected</string>
 </resources>

--- a/libraries/cyclestreets-view/src/main/res/values/styles.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/styles.xml
@@ -9,4 +9,7 @@
     <item name="android:windowBackground">@android:color/transparent</item>
     <item name="android:backgroundDimEnabled">true</item>
   </style>
+
+  <dimen name="CRmargin">8dp</dimen>
+
 </resources>


### PR DESCRIPTION
Fixes #465 

### Brief summary of changes:

- Changed CircularRouteActivity / ViewModel to add in POI button and call to POI list dialog.
- Changed JOLT transform spec to transform POIs (single or multiple) and single or multiple waypoints (rather than just multiple ones as previously).
- Added CircularRoutePoiOverlay as subclass of LiveItemOverlay to display the circular route POIs
- Extracted Bubble functionality from POIOverlay so it can also be used by CircularRoutePoiOverlay
- Added Circular Route POIs to Journey (also stored them in the JourneyDomainObject).

### Other notes:

- In tappedInBubble I've removed the bit which adds a waymark (routeMarkerAtItem) as it doesn't make sense to me to add a waymark?  User can always tap again once the bubble has gone if they want to place a marker.

  @oliverlockwood @jezhiggins Let me know if you disagree, though, and I'll find a way to put it back in for POIOverlay.

- DrawBubble is handled in POIOverlay for both POIOverlay and CircularRoutePOIOverlay.

- I've made Bubble a singleton so that only one bubble will ever be shown, either from the Circular Route POIs or the regular POIs.  (Though, thinking about it, I suppose there wouldn't be much harm in having 2 bubbles – but it's done now.)

- fetchItemsinBackground – the one in CircularRoutePOIOverlay won't get called as onZoom and onScroll are overridden to do nothing.  It's not needed here as the POIs are all uploaded at the beginning for a circular route because there are only a few of them.  Is it OK to just override it to do nothing? (fetchItemsinBackground is called via onZoom and onScroll in LiveItemOverlay).

- Previously I thought that no waypoint was returned for circular routes, but in fact one is returned – it just wasn't getting transformed.  I've corrected the code for this (amended the JOLT spec to transform a single waypoint as well as multiple ones) and removed the code where I previously used the start point (longitude/latitude) instead, in RouteDomainObject and Journey.populateWaypoints.

- Note that the information passed in the API for the circular route POIs is less than that passed for non-route POIs. e.g. journey no. https://cycle.st/j75278584 has bike shops but opening hours aren't shown in the bubble for bike shop “Fully Charged”, whereas they are if you display bike shop POIs from the top right menu. 

- The screen layout design isn't brilliant, sorry!  I was really struggling to get everything in on the Nexus One in landscape mode (without creating a separate layout) and this means a big gap when it's in portrait mode.


[Screenshots of Circular Route with POIs.pdf](https://github.com/cyclestreets/android/files/6878694/Screenshots.of.Circular.Route.with.POIs.pdf)

[Landscape screenshots of Circular Route request screen with POIs button.pdf](https://github.com/cyclestreets/android/files/6878703/Landscape.screenshots.of.Circular.Route.request.screen.with.POIs.button.pdf)

[Test plan for Circular Route POIs.pdf](https://github.com/cyclestreets/android/files/6878700/Test.plan.for.Circular.Route.POIs.pdf)