### PR TITLE
Use current journey plan for LiveRide replans

### DIFF
--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -16,10 +16,10 @@ dependencies {
   api "org.mapsforge:mapsforge-themes:${rootProject.ext.mapsforgeVersion}"
   // there is some suggestion (https://github.com/osmdroid/osmdroid/wiki/Mapsforge) that the below may be necessary
 //  api "org.osmdroid:osmdroid-mapsforge:${rootProject.ext.osmdroidVersion}@aar"
-
-  api 'com.mikepenz:iconics-core:5.2.8@aar'
-  api 'com.mikepenz:iconics-typeface-api:5.2.8@aar'
-  implementation 'com.mikepenz:iconics-views:5.2.8@aar'
+// Icons disappear with 5.2.8 so reverting to 5.0.3 for now
+  api 'com.mikepenz:iconics-core:5.0.3@aar'
+  api 'com.mikepenz:iconics-typeface-api:5.0.3@aar'
+  implementation 'com.mikepenz:iconics-views:5.0.3@aar'
   api 'com.mikepenz:google-material-typeface:3.0.1.6.original-kotlin@aar'
 
   api 'com.google.android.material:material:1.3.0'

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/RouteData.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/content/RouteData.java
@@ -7,12 +7,12 @@ public class RouteData
   private final String name;
   private final String json;
   private final Waypoints points;
-  private final Boolean saveRoute;
+  private final boolean saveRoute;
 
   public RouteData(final String json,
                    final Waypoints points,
                    final String name,
-                   final Boolean saveRoute) {
+                   final boolean saveRoute) {
     this.json = json;
     this.points = points;
     this.name = name;
@@ -22,5 +22,5 @@ public class RouteData
   public String name() { return name; }
   public String json() { return json; }
   public Waypoints points() { return points; }
-  public Boolean saveRoute() { return saveRoute; }
+  public boolean saveRoute() { return saveRoute; }
 }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/ReplanFromHere.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/ReplanFromHere.kt
@@ -43,8 +43,7 @@ internal class ReplanFromHere(previous: LiveRideState, whereIam: GeoPoint) : Liv
             }
         }
         Route.softRegisterListener(this)
-        Route.LiveReplanRoute(CycleStreetsPreferences.routeType(),
-                              CycleStreetsPreferences.speed(),
+        Route.LiveReplanRoute(CycleStreetsPreferences.speed(),
                               context,
                               remainingWaypoints)
     }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
@@ -181,6 +181,11 @@ object Route {
         return plannedRoute_
     }
 
+    @JvmStatic
+    fun currentJourneyPlan(): String {
+        return currentJourneyPlan
+    }
+
     private fun loadLastJourney() {
         val routeSummaries = storedRoutes()
         if (!storedRoutes().isEmpty()) {

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/routing/Route.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import android.widget.Toast
 import net.cyclestreets.CycleStreetsPreferences
+import net.cyclestreets.RoutePlans
 import net.cyclestreets.content.RouteData
 import net.cyclestreets.content.RouteDatabase
 import net.cyclestreets.content.RouteSummary
@@ -17,6 +18,7 @@ import java.util.*
 object Route {
     private val TAG = Logging.getTag(Route::class.java)
     private val listeners_ = Listeners()
+    private var currentJourneyPlan: String = ""
     @JvmStatic
     fun registerListener(l: Listener) {
         listeners_.register(l)
@@ -50,11 +52,17 @@ object Route {
         query.execute(waypoints_)
     }
 
-    fun LiveReplanRoute(plan: String,
-                        speed: Int,
+    fun LiveReplanRoute(speed: Int,
                         context: Context,
                         waypoints: Waypoints) {
-        val query = LiveRideReplanRoutingTask(plan, speed, context)
+        var newPlan: String
+        // Check current plan is a linear route plan.
+        if (currentJourneyPlan in RoutePlans.allPlans())
+            newPlan = currentJourneyPlan
+        else
+            newPlan = RoutePlans.PLAN_QUIETEST
+
+        val query = LiveRideReplanRoutingTask(newPlan, speed, context)
         query.execute(waypoints)
     }
 
@@ -151,6 +159,7 @@ object Route {
             return
         }
         plannedRoute_ = loadFromJson(route.json(), route.points(), route.name())
+        currentJourneyPlan = plannedRoute_.plan()
         db_.saveRoute(plannedRoute_, route.json())
         waypoints_ = plannedRoute_.waypoints
         listeners_.onNewJourney(plannedRoute_, waypoints_)


### PR DESCRIPTION
Fixes #476 

[Test LiveRide replan uses current plan.pdf](https://github.com/cyclestreets/android/files/6940526/Test.LiveRide.replan.uses.current.plan.pdf)
