### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
 
 # Get the full commit history (required to derive our version code, see the root build.gradle)
 git:
-  depth: false
+  depth: 3
 
 language: android
 addons:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.