### PR TITLE
patch(data loss) 1

### DIFF
--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
@@ -295,7 +295,6 @@ public class CycleStreetsPreferences
     editor.putString(PREF_CONFIRM_PASSWORD_KEY, confirmPassword);
     editor.putString(PREF_NAME_KEY, name);
     editor.putString(PREF_EMAIL_KEY, email);
-    editor.putBoolean(PREF_VALIDATED_KEY, false);
     editor.commit();
   }
 
@@ -308,6 +307,16 @@ public class CycleStreetsPreferences
     editor.putString(PREF_CONFIRM_PASSWORD_KEY, "");
     editor.putBoolean(PREF_PENDING_KEY, false);
     editor.putBoolean(PREF_VALIDATED_KEY, false);
+    editor.commit();
+  }
+
+  public static void clearTempUsernamePassword() {
+    final Editor editor = editor();
+    editor.putString(PREF_USERNAME_KEY, "");
+    editor.putString(PREF_PASSWORD_KEY, "");
+    editor.putString(PREF_NAME_KEY, "");
+    editor.putString(PREF_EMAIL_KEY, "");
+    editor.putString(PREF_CONFIRM_PASSWORD_KEY, "");
     editor.commit();
   }
 

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
@@ -285,18 +285,16 @@ public class CycleStreetsPreferences
   }
 
   public static void setTempUsernamePassword(final String username,
-                                             final String password,
-                                             final String confirmPassword,
-                                             final String name,
-                                             final String email,
-                                             final boolean pending) {
+                                                final String password,
+                                                final String confirmPassword,
+                                                final String name,
+                                                final String email) {
     final Editor editor = editor();
     editor.putString(PREF_USERNAME_KEY, username);
     editor.putString(PREF_PASSWORD_KEY, password);
     editor.putString(PREF_CONFIRM_PASSWORD_KEY, confirmPassword);
     editor.putString(PREF_NAME_KEY, name);
     editor.putString(PREF_EMAIL_KEY, email);
-    editor.putBoolean(PREF_PENDING_KEY, pending);
     editor.putBoolean(PREF_VALIDATED_KEY, false);
     editor.commit();
   }
@@ -307,6 +305,7 @@ public class CycleStreetsPreferences
     editor.putString(PREF_PASSWORD_KEY, "");
     editor.putString(PREF_NAME_KEY, "");
     editor.putString(PREF_EMAIL_KEY, "");
+    editor.putString(PREF_CONFIRM_PASSWORD_KEY, "");
     editor.putBoolean(PREF_PENDING_KEY, false);
     editor.putBoolean(PREF_VALIDATED_KEY, false);
     editor.commit();

--- a/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
+++ b/libraries/cyclestreets-core/src/main/java/net/cyclestreets/CycleStreetsPreferences.java
@@ -23,6 +23,7 @@ public class CycleStreetsPreferences
   public final static String PREF_CONFIRM_NEW_ROUTE = "confirm-new-route";
   public final static String PREF_USERNAME_KEY = "username";
   public final static String PREF_PASSWORD_KEY = "password";
+  public final static String PREF_CONFIRM_PASSWORD_KEY = "confirm_password";
   public final static String PREF_EMAIL_KEY = "email";
   public final static String PREF_NAME_KEY = "name";
   public final static String PREF_VALIDATED_KEY = "signed-in";
@@ -276,6 +277,23 @@ public class CycleStreetsPreferences
     final Editor editor = editor();
     editor.putString(PREF_USERNAME_KEY, username);
     editor.putString(PREF_PASSWORD_KEY, password);
+    editor.putString(PREF_NAME_KEY, name);
+    editor.putString(PREF_EMAIL_KEY, email);
+    editor.putBoolean(PREF_PENDING_KEY, pending);
+    editor.putBoolean(PREF_VALIDATED_KEY, false);
+    editor.commit();
+  }
+
+  public static void setTempUsernamePassword(final String username,
+                                             final String password,
+                                             final String confirmPassword,
+                                             final String name,
+                                             final String email,
+                                             final boolean pending) {
+    final Editor editor = editor();
+    editor.putString(PREF_USERNAME_KEY, username);
+    editor.putString(PREF_PASSWORD_KEY, password);
+    editor.putString(PREF_CONFIRM_PASSWORD_KEY, confirmPassword);
     editor.putString(PREF_NAME_KEY, name);
     editor.putString(PREF_EMAIL_KEY, email);
     editor.putBoolean(PREF_PENDING_KEY, pending);

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
@@ -53,6 +53,8 @@ public class AccountDetailsActivity extends Activity
   private View signinDetails_;
   private Button signinButton_;
 
+  private boolean isSubmit;
+
   @Override
   public void onCreate(final Bundle saved) {
     super.onCreate(saved);
@@ -78,7 +80,37 @@ public class AccountDetailsActivity extends Activity
   }
 
   @Override
+  protected void onPause() {
+    super.onPause();
+    if (isSubmit) {
+      CycleStreetsPreferences.clearUsernamePassword();
+    } else {
+      saveUserData();
+    }
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    isSubmit = false;
+  }
+
+  private void saveUserData(){
+    final String username = getText(registerDetails_, R.id.username);
+    final String password = getText(registerDetails_, R.id.password);
+    final String confirmPassword = getText(registerDetails_, R.id.confirm_password);
+    final String name = getText(registerDetails_, R.id.name);
+    final String email = getText(registerDetails_, R.id.email);
+    CycleStreetsPreferences.setTempUsernamePassword(username, password, confirmPassword, name, email, true);
+  }
+
+  @Override
   public void onBackPressed() {
+    if (isSubmit) {
+      CycleStreetsPreferences.clearUsernamePassword();
+    } else {
+      saveUserData();
+    }
     step_ = step_.prev();
 
     if (step_ != null)
@@ -325,6 +357,7 @@ public class AccountDetailsActivity extends Activity
     protected void onPostExecute(final Result result) {
       progress_.dismiss();
       CycleStreetsPreferences.setPendingUsernamePassword(username_, password_, name_, email_, result.ok());
+      isSubmit = result.ok();
       MessageBox(result.message(), result.ok());
     }
   }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
@@ -89,7 +89,7 @@ public class AccountDetailsActivity extends Activity
         super.onPause();
         if (isSubmit) {
             //If successfully registered, clear user details.
-            CycleStreetsPreferences.clearUsernamePassword();
+            CycleStreetsPreferences.clearTempUsernamePassword();
         } else {
             saveUserData();
         }
@@ -104,8 +104,8 @@ public class AccountDetailsActivity extends Activity
     @Override
     public void onBackPressed() {
         if (isSubmit) {
-            //If successfully registered, clear user details.
-            CycleStreetsPreferences.clearUsernamePassword();
+            //If successfully registered, clear user details.z
+            CycleStreetsPreferences.clearTempUsernamePassword();
         } else {
             saveUserData();
         }

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/AccountDetailsActivity.java
@@ -22,354 +22,365 @@ import android.widget.Button;
 import android.widget.TextView;
 
 public class AccountDetailsActivity extends Activity
-                  implements View.OnClickListener, TextWatcher
-{
-  public enum RegisterStep  {
-    ACCOUNT(null),
+        implements View.OnClickListener, TextWatcher {
+    public enum RegisterStep {
+        ACCOUNT(null),
 
-    REGISTER_DETAILS(ACCOUNT),
+        REGISTER_DETAILS(ACCOUNT),
 
-    SIGNIN_DETAILS(ACCOUNT),
+        SIGNIN_DETAILS(ACCOUNT),
 
-    EXISTING_SIGNIN_DETAILS(null);
+        EXISTING_SIGNIN_DETAILS(null);
 
-    RegisterStep(final RegisterStep p) {
-      prev_ = p;
-      if (prev_ != null)
-        prev_.next_ = this;
+        RegisterStep(final RegisterStep p) {
+            prev_ = p;
+            if (prev_ != null)
+                prev_.next_ = this;
+        }
+
+        public RegisterStep prev() {
+            return prev_;
+        }
+
+        public RegisterStep next() {
+            return next_;
+        }
+
+        private RegisterStep prev_;
+        private RegisterStep next_;
     }
 
-    public RegisterStep prev() { return prev_; }
-    public RegisterStep next() { return next_; }
+    private RegisterStep step_;
 
-    private RegisterStep prev_;
-    private RegisterStep next_;
-  }
+    private View registerView_;
+    private View registerDetails_;
+    private View signinDetails_;
+    private Button signinButton_;
 
-  private RegisterStep step_;
+    private boolean isSubmit;
 
-  private View registerView_;
-  private View registerDetails_;
-  private View signinDetails_;
-  private Button signinButton_;
+    @Override
+    public void onCreate(final Bundle saved) {
+        super.onCreate(saved);
 
-  private boolean isSubmit;
+        final LayoutInflater inflater = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
-  @Override
-  public void onCreate(final Bundle saved) {
-    super.onCreate(saved);
+        final InputFilter[] usernameFilters = new InputFilter[]{new WhitespaceInputFilter()};
 
-    final LayoutInflater inflater = (LayoutInflater)getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        registerView_ = inflater.inflate(R.layout.accountdetails, null);
+        registerDetails_ = inflater.inflate(R.layout.accountregister, null);
+        textView(registerDetails_, R.id.username).setFilters(usernameFilters);
+        signinDetails_ = inflater.inflate(R.layout.accountsignin, null);
+        signinButton_ = (Button) signinDetails_.findViewById(R.id.signin_button);
+        TextView usernameTV = textView(signinDetails_, R.id.username);
+        usernameTV.addTextChangedListener(this);
+        usernameTV.setFilters(usernameFilters);
+        textView(signinDetails_, R.id.password).addTextChangedListener(this);
+        signinButton_.setEnabled(false);
 
-    final InputFilter[] usernameFilters = new InputFilter[]{ new WhitespaceInputFilter() };
+        step_ = (CycleStreetsPreferences.accountOK()) ? RegisterStep.EXISTING_SIGNIN_DETAILS : RegisterStep.ACCOUNT;
 
-    registerView_ = inflater.inflate(R.layout.accountdetails, null);
-    registerDetails_ = inflater.inflate(R.layout.accountregister, null);
-    textView(registerDetails_, R.id.username).setFilters(usernameFilters);
-    signinDetails_ = inflater.inflate(R.layout.accountsignin, null);
-    signinButton_ = (Button)signinDetails_.findViewById(R.id.signin_button);
-    TextView usernameTV = textView(signinDetails_, R.id.username);
-    usernameTV.addTextChangedListener(this);
-    usernameTV.setFilters(usernameFilters);
-    textView(signinDetails_, R.id.password).addTextChangedListener(this);
-    signinButton_.setEnabled(false);
-
-    step_ = (CycleStreetsPreferences.accountOK()) ? RegisterStep.EXISTING_SIGNIN_DETAILS : RegisterStep.ACCOUNT;
-
-    setupView();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    if (isSubmit) {
-      CycleStreetsPreferences.clearUsernamePassword();
-    } else {
-      saveUserData();
-    }
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    isSubmit = false;
-  }
-
-  private void saveUserData(){
-    final String username = getText(registerDetails_, R.id.username);
-    final String password = getText(registerDetails_, R.id.password);
-    final String confirmPassword = getText(registerDetails_, R.id.confirm_password);
-    final String name = getText(registerDetails_, R.id.name);
-    final String email = getText(registerDetails_, R.id.email);
-    CycleStreetsPreferences.setTempUsernamePassword(username, password, confirmPassword, name, email, true);
-  }
-
-  @Override
-  public void onBackPressed() {
-    if (isSubmit) {
-      CycleStreetsPreferences.clearUsernamePassword();
-    } else {
-      saveUserData();
-    }
-    step_ = step_.prev();
-
-    if (step_ != null)
-      setupView();
-    else
-      super.onBackPressed();
-  }
-
-  private void setupView() {
-    switch(step_) {
-    case ACCOUNT:
-      setContentView(registerView_);
-      hookUpButton(registerView_, R.id.newaccount_button);
-      hookUpButton(registerView_, R.id.existingaccount_button);
-      break;
-    case REGISTER_DETAILS:
-      setContentView(registerDetails_);
-      setText(registerDetails_, R.id.username, CycleStreetsPreferences.username());
-      setText(registerDetails_, R.id.password, CycleStreetsPreferences.password());
-      setText(registerDetails_, R.id.name, CycleStreetsPreferences.name());
-      setText(registerDetails_, R.id.email, CycleStreetsPreferences.email());
-      setText(registerDetails_, R.id.registration_message, registrationMessage());
-      hookUpButton(registerDetails_, R.id.register_button);
-      break;
-    case SIGNIN_DETAILS:
-    case EXISTING_SIGNIN_DETAILS:
-      setContentView(signinDetails_);
-      setText(signinDetails_, R.id.username, CycleStreetsPreferences.username());
-      setText(signinDetails_, R.id.password, CycleStreetsPreferences.password());
-      setText(signinDetails_, R.id.signin_message, signinMessage());
-
-      hookUpButton(signinDetails_, R.id.signin_button);
-      hookUpButton(signinDetails_, R.id.cleardetails_button);
-      break;
-    }
-  }
-
-  private String signinMessage() {
-    if (CycleStreetsPreferences.accountOK())
-      return getString(R.string.account_already_signed_in_format,
-                       CycleStreetsPreferences.name(),
-                       CycleStreetsPreferences.email());
-    return getString(R.string.account_signin_message);
-  }
-
-  private String registrationMessage() {
-    if (CycleStreetsPreferences.accountPending())
-      return getString(R.string.account_pending);
-    return getString(R.string.account_registration_is_free_long);
-  }
-
-  private void hookUpButton(final View v, final int id) {
-    final Button b = (Button)v.findViewById(id);
-    if (b == null)
-      return;
-    b.setOnClickListener(this);
-  }
-
-  private TextView textView(final View v, final int id) {
-    return (TextView)v.findViewById(id);
-  }
-
-  private void setText(final View v, final int id, final String value) {
-    final TextView tv = textView(v, id);
-    if (tv == null)
-      return;
-    tv.setText(value);
-  }
-
-  private String getText(final View v, final int id) {
-    final TextView tv = textView(v, id);
-    return tv.getText().toString();
-  }
-
-  @Override
-  public void onClick(final View v) {
-    final int clicked  = v.getId();
-
-    if (R.id.newaccount_button == clicked)
-        step_ = RegisterStep.REGISTER_DETAILS;
-    if (R.id.existingaccount_button == clicked)
-        step_ = RegisterStep.SIGNIN_DETAILS;
-    if (R.id.cleardetails_button == clicked)
-        confirmClear();
-    if (R.id.signin_button == clicked) {
-        signin();
-        return;
-    }
-    if (R.id.register_button == clicked) {
-        register();
-        return;
+        setupView();
     }
 
-    setupView();
-  }
-  ///////////////////////////////////////////////////////
 
-  @Override
-  public void afterTextChanged(Editable arg0) { }
-  @Override
-  public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
-  @Override
-  public void onTextChanged(CharSequence s, int start, int before, int count) {
-    final String username = getText(signinDetails_, R.id.username);
-    final String password = getText(signinDetails_, R.id.password);
-    signinButton_.setEnabled((username.length() != 0) && (password.length() != 0));
-  }
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (isSubmit) {
+            //If successfully registered, clear user details.
+            CycleStreetsPreferences.clearUsernamePassword();
+        } else {
+            saveUserData();
+        }
+    }
 
-  ///////////////////////////////////////////////////////
-  private void confirmClear() {
-    MessageBox.YesNo(signinDetails_,
-             getString(R.string.account_clear_details_confirm),
-             new DialogInterface.OnClickListener() {
+    @Override
+    protected void onResume() {
+        super.onResume();
+        isSubmit = false;
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (isSubmit) {
+            //If successfully registered, clear user details.
+            CycleStreetsPreferences.clearUsernamePassword();
+        } else {
+            saveUserData();
+        }
+        step_ = step_.prev();
+
+        if (step_ != null)
+            setupView();
+        else
+            super.onBackPressed();
+    }
+
+    private void saveUserData(){
+        final String username = getText(registerDetails_, R.id.username);
+        final String password = getText(registerDetails_, R.id.password);
+        final String confirmPassword = getText(registerDetails_, R.id.confirm_password);
+        final String name = getText(registerDetails_, R.id.name);
+        final String email = getText(registerDetails_, R.id.email);
+        CycleStreetsPreferences.setTempUsernamePassword(username, password, confirmPassword, name, email);
+    }
+
+    private void setupView() {
+        switch (step_) {
+            case ACCOUNT:
+                setContentView(registerView_);
+                hookUpButton(registerView_, R.id.newaccount_button);
+                hookUpButton(registerView_, R.id.existingaccount_button);
+                break;
+            case REGISTER_DETAILS:
+                setContentView(registerDetails_);
+                setText(registerDetails_, R.id.username, CycleStreetsPreferences.username());
+                setText(registerDetails_, R.id.password, CycleStreetsPreferences.password());
+                setText(registerDetails_, R.id.name, CycleStreetsPreferences.name());
+                setText(registerDetails_, R.id.email, CycleStreetsPreferences.email());
+                setText(registerDetails_, R.id.registration_message, registrationMessage());
+                hookUpButton(registerDetails_, R.id.register_button);
+                break;
+            case SIGNIN_DETAILS:
+            case EXISTING_SIGNIN_DETAILS:
+                setContentView(signinDetails_);
+                setText(signinDetails_, R.id.username, CycleStreetsPreferences.username());
+                setText(signinDetails_, R.id.password, CycleStreetsPreferences.password());
+                setText(signinDetails_, R.id.signin_message, signinMessage());
+
+                hookUpButton(signinDetails_, R.id.signin_button);
+                hookUpButton(signinDetails_, R.id.cleardetails_button);
+                break;
+        }
+    }
+
+    private String signinMessage() {
+        if (CycleStreetsPreferences.accountOK())
+            return getString(R.string.account_already_signed_in_format,
+                    CycleStreetsPreferences.name(),
+                    CycleStreetsPreferences.email());
+        return getString(R.string.account_signin_message);
+    }
+
+    private String registrationMessage() {
+        if (CycleStreetsPreferences.accountPending())
+            return getString(R.string.account_pending);
+        return getString(R.string.account_registration_is_free_long);
+    }
+
+    private void hookUpButton(final View v, final int id) {
+        final Button b = (Button) v.findViewById(id);
+        if (b == null)
+            return;
+        b.setOnClickListener(this);
+    }
+
+    private TextView textView(final View v, final int id) {
+        return (TextView) v.findViewById(id);
+    }
+
+    private void setText(final View v, final int id, final String value) {
+        final TextView tv = textView(v, id);
+        if (tv == null)
+            return;
+        tv.setText(value);
+    }
+
+    private String getText(final View v, final int id) {
+        final TextView tv = textView(v, id);
+        return tv.getText().toString();
+    }
+
+    @Override
+    public void onClick(final View v) {
+        final int clicked = v.getId();
+
+        if (R.id.newaccount_button == clicked)
+            step_ = RegisterStep.REGISTER_DETAILS;
+        if (R.id.existingaccount_button == clicked)
+            step_ = RegisterStep.SIGNIN_DETAILS;
+        if (R.id.cleardetails_button == clicked)
+            confirmClear();
+        if (R.id.signin_button == clicked) {
+            signin();
+            return;
+        }
+        if (R.id.register_button == clicked) {
+            register();
+            return;
+        }
+
+        setupView();
+    }
+    ///////////////////////////////////////////////////////
+
+    @Override
+    public void afterTextChanged(Editable arg0) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        final String username = getText(signinDetails_, R.id.username);
+        final String password = getText(signinDetails_, R.id.password);
+        signinButton_.setEnabled((username.length() != 0) && (password.length() != 0));
+    }
+
+    ///////////////////////////////////////////////////////
+    private void confirmClear() {
+        MessageBox.YesNo(signinDetails_,
+                getString(R.string.account_clear_details_confirm),
+                new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface arg0, int arg1) {
-                      CycleStreetsPreferences.clearUsernamePassword();
-                      setupView();
+                        CycleStreetsPreferences.clearUsernamePassword();
+                        setupView();
                     }
-                  });
-  }
-
-  ////////////////////////////////////////////////////////
-  private void MessageBox(final String message, final boolean finishOnOK) {
-    MessageBox.OKAndFinish(signinDetails_, message, this, finishOnOK);
-  }
-
-  ////////////////////////////////////////////////////////
-  private void signin() {
-    final String username = getText(signinDetails_, R.id.username);
-    final String password = getText(signinDetails_, R.id.password);
-
-    if ((username.length() == 0) || (password.length() == 0)) {
-      MessageBox("Please enter username and password.", false);
-      return;
-    }
-    final SignInTask task = new SignInTask(this, username, password);
-    task.execute();
-  }
-
-  private class SignInTask extends AsyncTask<Object, Void, Signin.Result>  {
-    private final String username_;
-    private final String password_;
-    private final ProgressDialog progress_;
-
-    SignInTask(final Context context,
-                final String username,
-                final String password) {
-      username_ = username;
-      password_ = password;
-
-      progress_ = Dialog.createProgressDialog(context, R.string.account_signing_in);
+                });
     }
 
-    @Override
-    protected void onPreExecute() {
-      super.onPreExecute();
-      progress_.show();
+    ////////////////////////////////////////////////////////
+    private void MessageBox(final String message, final boolean finishOnOK) {
+        MessageBox.OKAndFinish(signinDetails_, message, this, finishOnOK);
     }
 
-    protected Signin.Result doInBackground(Object... params) {
-      return Signin.signin(username_, password_);
+    ////////////////////////////////////////////////////////
+    private void signin() {
+        final String username = getText(signinDetails_, R.id.username);
+        final String password = getText(signinDetails_, R.id.password);
+
+        if ((username.length() == 0) || (password.length() == 0)) {
+            MessageBox("Please enter username and password.", false);
+            return;
+        }
+        final SignInTask task = new SignInTask(this, username, password);
+        task.execute();
     }
 
-    @Override
-    protected void onPostExecute(final Signin.Result result) {
-      progress_.dismiss();
+    private class SignInTask extends AsyncTask<Object, Void, Signin.Result> {
+        private final String username_;
+        private final String password_;
+        private final ProgressDialog progress_;
 
-      CycleStreetsPreferences.setUsernamePassword(username_,
-                            password_,
-                            result.name(),
-                            result.email(),
-                            result.ok());
-      setText(signinDetails_, R.id.signin_message, signinMessage());
+        SignInTask(final Context context,
+                   final String username,
+                   final String password) {
+            username_ = username;
+            password_ = password;
 
-      MessageBox(result.message(), result.ok());
-    }
-  }
+            progress_ = Dialog.createProgressDialog(context, R.string.account_signing_in);
+        }
 
-  ////////////////////////////////////////////////////////
-  private void register() {
-    final String emailRegex = "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$";
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            progress_.show();
+        }
 
-    final String username = getText(registerDetails_, R.id.username);
-    final String password = getText(registerDetails_, R.id.password);
-    final String password2 = getText(registerDetails_, R.id.confirm_password);
-    final String name = getText(registerDetails_, R.id.name);
-    final String email = getText(registerDetails_, R.id.email);
+        protected Signin.Result doInBackground(Object... params) {
+            return Signin.signin(username_, password_);
+        }
 
-    String oops = null;
+        @Override
+        protected void onPostExecute(final Signin.Result result) {
+            progress_.dismiss();
 
-    if (!email.toLowerCase().matches(emailRegex))
-      oops = getString(R.string.account_email_format);
-    if (!password.equals(password2))
-      oops = getString(R.string.account_password_mismatch);
-    if (username.length() < 5)
-      oops = getString(R.string.account_username_too_short);
+            CycleStreetsPreferences.setUsernamePassword(username_,
+                    password_,
+                    result.name(),
+                    result.email(),
+                    result.ok());
+            setText(signinDetails_, R.id.signin_message, signinMessage());
 
-    if (oops != null) {
-      MessageBox(oops, false);
-      return;
-    }
-
-    final RegisterTask task = new RegisterTask(this,
-                                               username,
-                                               password,
-                                               name,
-                                               email);
-    task.execute();
-  }
-
-  private class RegisterTask extends AsyncTask<Object, Void, Result>  {
-    private final String username_;
-    private final String password_;
-    private final String name_;
-    private final String email_;
-    private final ProgressDialog progress_;
-
-    RegisterTask(final Context context,
-                 final String username,
-                 final String password,
-                 final String name,
-                 final String email) {
-      username_ = username;
-      password_ = password;
-      name_ = name;
-      email_ = email;
-
-      progress_ = Dialog.createProgressDialog(context, R.string.account_registering);
+            MessageBox(result.message(), result.ok());
+        }
     }
 
-    @Override
-    protected void onPreExecute() {
-      super.onPreExecute();
-      progress_.show();
+    ////////////////////////////////////////////////////////
+    private void register() {
+        final String emailRegex = "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$";
+
+        final String username = getText(registerDetails_, R.id.username);
+        final String password = getText(registerDetails_, R.id.password);
+        final String password2 = getText(registerDetails_, R.id.confirm_password);
+        final String name = getText(registerDetails_, R.id.name);
+        final String email = getText(registerDetails_, R.id.email);
+
+        String oops = null;
+
+        if (!email.toLowerCase().matches(emailRegex))
+            oops = getString(R.string.account_email_format);
+        if (!password.equals(password2))
+            oops = getString(R.string.account_password_mismatch);
+        if (username.length() < 5)
+            oops = getString(R.string.account_username_too_short);
+
+        if (oops != null) {
+            MessageBox(oops, false);
+            return;
+        }
+
+        final RegisterTask task = new RegisterTask(this,
+                username,
+                password,
+                name,
+                email);
+        task.execute();
     }
 
-    protected Result doInBackground(Object... params) {
-      return Registration.register(username_,
-                                   password_,
-                                   name_,
-                                   email_);
+    private class RegisterTask extends AsyncTask<Object, Void, Result> {
+        private final String username_;
+        private final String password_;
+        private final String name_;
+        private final String email_;
+        private final ProgressDialog progress_;
+
+        RegisterTask(final Context context,
+                     final String username,
+                     final String password,
+                     final String name,
+                     final String email) {
+            username_ = username;
+            password_ = password;
+            name_ = name;
+            email_ = email;
+
+            progress_ = Dialog.createProgressDialog(context, R.string.account_registering);
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            progress_.show();
+        }
+
+        protected Result doInBackground(Object... params) {
+            return Registration.register(username_,
+                    password_,
+                    name_,
+                    email_);
+        }
+
+        @Override
+        protected void onPostExecute(final Result result) {
+            progress_.dismiss();
+            CycleStreetsPreferences.setPendingUsernamePassword(username_, password_, name_, email_, result.ok());
+            isSubmit = result.ok();
+            MessageBox(result.message(), result.ok());
+        }
     }
 
-    @Override
-    protected void onPostExecute(final Result result) {
-      progress_.dismiss();
-      CycleStreetsPreferences.setPendingUsernamePassword(username_, password_, name_, email_, result.ok());
-      isSubmit = result.ok();
-      MessageBox(result.message(), result.ok());
-    }
-  }
+    private class WhitespaceInputFilter extends LoginFilter.UsernameFilterGeneric {
+        public WhitespaceInputFilter() {
+            super(false);
+        }
 
-  private class WhitespaceInputFilter extends LoginFilter.UsernameFilterGeneric {
-    public WhitespaceInputFilter() {
-      super(false);
+        @Override
+        public boolean isAllowed(char c) {
+            return !Character.isWhitespace(c);
+        }
     }
-
-    @Override
-    public boolean isAllowed(char c) {
-      return !Character.isWhitespace(c);
-    }
-  }
 }


### PR DESCRIPTION
Hello developers of CycleStreets

I am using your app CycleStreets. I think the app is great but I have one minor patch that could improve the user experience.

Here are some pictures to help illustrate my patch: https://imgur.com/a/S7iCRWB

In picture 1, a user has partially filed out his registration information. If something like a phone call moves the screen to another activity or if the user accidentally closes the app or presses back. The app should preserve the data in this case. However, once the user returns he will lose information he had filed in so far. This can be seen in pictures 1 and 2. Our patch will preserve this data so there will be no data loss in situations like this.

Another issue is when the user finishes registration. When the user wants to register another account. The information of the previous account is pre-filled out as can be seen in picture 3. This is inconvenient as they have to manually delete the data. It could also be misleading since typically, in other apps, you would preserve this data when registration is not complete. Our patch will clear this data if registration is successful.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim