### PR TITLE
POI link fixed for Android 11

### DIFF
--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/Bubble.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/overlay/Bubble.kt
@@ -56,9 +56,11 @@ object Bubble {
             val webpage = Uri.parse(url)
             val intent = Intent(Intent.ACTION_VIEW, webpage)
 
-            if (intent.resolveActivity(context.getPackageManager()) != null) {
+            try {
                 ContextCompat.startActivity(context, intent, null)
             }
+            // If there is no app to launch the URL then an error will occur.  No need to do anything in that case.
+            catch(e: Exception) {}
         }
     }
 


### PR DESCRIPTION
Fixes #508 
Tested on Pixel 4 API 30 (Android 11), Nexus 6 API 29 (Android 10) to check POI link worked, and my own phone, Fairphone 3, Android 11, to check app selector came up.