### PR TITLE
Correct POI test now the icons have been fixed up

### DIFF
--- a/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/RetrofitApiClientTest.java
+++ b/libraries/cyclestreets-core/src/test/java/net/cyclestreets/api/client/RetrofitApiClientTest.java
@@ -110,7 +110,7 @@ public class RetrofitApiClientTest {
                     .withHeader("Content-Type", "application/json")
                     .withHeader("Cache-Control", "public, max-age=604800")
                     .withBodyFile("pois-types.json")));
-    when(testResources.getResourcePackageName(R.drawable.poi_bedsforcyclists)).thenReturn("drawable-xxhdpi");
+    when(testResources.getResourcePackageName(R.drawable.poi_attractions)).thenReturn("drawable-xxhdpi");
     when(testResources.getDrawable(anyInt(), eq(null))).thenReturn(mock(Drawable.class));
 
     // when


### PR DESCRIPTION
Failing test after redoing the icons.  It looks like the one icon the test relied on is one that's been removed. :roll_eyes: 