### PR TITLE
Move to Target level 31. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ addons:
 env:
   global:
     # Remember to keep these four values in sync with values in the root build.gradle file
-    - compileSdkVersion=30
+    - compileSdkVersion=31
     - minSdkVersion=23
-    - targetSdkVersion=29
+    - targetSdkVersion=31
     - toolsVersion=30.0.3
     - JAVA8_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - JAVA9_HOME=/usr/lib/jvm/java-9-openjdk-amd64

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ ext {
   // Android 4.2, 4.2.2  17  JELLY_BEAN_MR1
 
   // Remember to keep these values in sync with .travis.yml
-  compileSdkVersion=30
+  compileSdkVersion=31
   minSdkVersion=23
-  targetSdkVersion=30
+  targetSdkVersion=31
   buildToolsVersion='30.0.3'
 
   // java version


### PR DESCRIPTION
This is required by Google to upload to play store

Probably going to have to follow up with a load of Gradle updates, plugin bumps, etc, etc, before getting down to trying to sort out all the deprecations that have accumulated/been thrust upon us in the past couple of years. 

One step at a time. 