### PR TITLE
Bump java version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ language: android
 addons:
   apt:
     packages:
-      - openjdk-9-jdk
       - openjdk-11-jdk
 env:
   global:
@@ -29,8 +28,6 @@ env:
     - minSdkVersion=23
     - targetSdkVersion=31
     - toolsVersion=30.0.3
-    - JAVA8_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - JAVA9_HOME=/usr/lib/jvm/java-9-openjdk-amd64
     - JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
     # For the decryption of secrets needed to sign and publish our artifacts
     - secure: "LipL0wPv0uQrKitaeGxCpoQsx5sl/Pg/DtQv4S7Bi52DxfArgvD2hPB0TWgkgYGJPfENHLEyqg+H+/v2nON3IXY+cnsd+TW+P1T03/52D56ieSKGVtVtSYUOZUgoyxIIvRZWFh/UNg+AmZIjOCTJDLitBTUxD8kWux8NjhIqZow="
@@ -49,14 +46,14 @@ before_install:
   - ./ciLicense.sh
   - sudo pip install requests
   - touch $HOME/.android/repositories.cfg
-  - jdk_switcher use openjdk8
+  - jdk_switcher use openjdk11
   - yes | sdkmanager "platforms;android-31"
   - yes | sdkmanager "build-tools;30.0.3"
 
 install:
   - ls -l /usr/lib/jvm/
   - ./checkPoiTypeIcons.sh
-  - JAVA_HOME=${JAVA9_HOME} ./gradlew build -Dorg.gradle.java.home=${JAVA9_HOME} -x lint
+  - JAVA_HOME=${JAVA11_HOME} ./gradlew build -Dorg.gradle.java.home=${JAVA11_HOME} -x lint
 
 script:
   - ./ciPublish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   - ./ciLicense.sh
   - sudo pip install requests
   - touch $HOME/.android/repositories.cfg
-  - jdk_switcher use openjdk11
   - yes | sdkmanager "platforms;android-31"
   - yes | sdkmanager "build-tools;30.0.3"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-  ext.kotlinVersion = '1.4.31'
+  ext.kotlinVersion = '1.6.21'
   repositories {
     google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
+    classpath 'com.android.tools.build:gradle:7.4.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.3'
+    classpath 'com.android.tools.build:gradle:4.2.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   }
 }
@@ -34,7 +34,7 @@ ext {
   buildToolsVersion='30.0.3'
 
   // java version
-  javaVersion = JavaVersion.VERSION_1_8
+  javaVersion = JavaVersion.VERSION_11
 
   // centrally manage some other dependencies
   mapsforgeVersion = '0.13.0' // TODO: 0.14.0 is available

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -84,8 +84,8 @@ dependencies {
   api project(':libraries:cyclestreets-fragments')
   implementation 'androidx.startup:startup-runtime:1.0.0'
 
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-  androidTestImplementation 'androidx.test:rules:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+  androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
 }

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
   dependencies {
-    classpath 'me.moallemi.gradle:advanced-build-version:1.7.3'
+    classpath 'me.moallemi.gradle:advanced-build-version:2.0.1'
   }
 }
 
 plugins {
-  id 'com.github.triplet.play' version '3.5.0'
+  id 'com.github.triplet.play' version '3.6.0'
 }
 
 // Use a plugin to derive a version name (e.g. 3.7) and monotonically increasing version code (e.g. 1372)

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.triplet.play' version '3.3.0'
+  id 'com.github.triplet.play' version '3.5.0'
 }
 
 // Use a plugin to derive a version name (e.g. 3.7) and monotonically increasing version code (e.g. 1372)

--- a/cyclestreets.app/src/main/AndroidManifest.xml
+++ b/cyclestreets.app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
     android:supportsRtl="false">
     <activity
       android:name=".CycleStreets"
-      android:label="@string/app_name">
+      android:label="@string/app_name"
+      android:exported="true" >
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -76,14 +77,16 @@
       </intent-filter>
     </activity>
     <activity android:name="net.cyclestreets.AboutActivity"
-              android:label="About">
+              android:label="About"
+              android:exported="false">
       <intent-filter>
         <action android:name="net.cyclestreets.AboutActivity" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </activity>
     <activity android:name="net.cyclestreets.LocationsActivity"
-              android:label="Locations">
+              android:label="Locations"
+              android:exported="false">
       <intent-filter>
         <action android:name="net.cyclestreets.LocationsActivity" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip

--- a/libraries/cyclestreets-view/build.gradle
+++ b/libraries/cyclestreets-view/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   api 'androidx.exifinterface:exifinterface:1.3.2'
   api 'androidx.preference:preference:1.1.1'
 
-  testImplementation 'androidx.test:core:1.3.0'
-  testImplementation 'androidx.test.ext:junit:1.1.2'
+  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation 'androidx.test.ext:junit:1.1.5'
   testImplementation "junit:junit:${rootProject.ext.junitVersion}"
   testImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
   testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoVersion}"


### PR DESCRIPTION
Move to Target 31 finally built green, but then the publish step fell over. 

So, we've got to bump to Java 11, and that's triggered it's own series of cascading changes :roll_eyes: 