### PR TITLE
Add PendingIntent.FLAG_IMMUTABLE

### DIFF
--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -14,7 +14,7 @@ advancedVersioning {
   nameOptions {
     versionMajor 3
     versionMinor 10
-    versionPatch 0
+    versionPatch 1
   }
   codeOptions {
     versionCodeType 'GIT_COMMIT_COUNT'

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/liveride/LiveRideState.kt
@@ -86,7 +86,11 @@ internal abstract class LiveRideState(protected val context: Context,
 
     private fun getNotification(text: String, ticker: String, directionIcon: Int? = null): Notification {
         val notificationIntent = Intent(context, LiveRideActivity::class.java)
-        val contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+        val contentIntent = PendingIntent.getActivity(
+                context,
+                0,
+                notificationIntent,
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
         val notificationBuilder = CycleStreetsNotifications.getBuilder(context, CHANNEL_LIVERIDE_ID)
                 .setSmallIcon(materialIcon(context, GoogleMaterial.Icon.gmd_directions_bike).toAndroidIconCompat().toIcon(context))


### PR DESCRIPTION
This was a breaking change in the enforced move to the new API level. I don't think there was a build warning for it (although having identified the problem, the IDE has a squigly under the offending line). Even if there was I would have missed it in all the deprecation warnings to which we are now subject.