### PR TITLE
542 write external storage deprecated

### DIFF
--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,0 +1,2 @@
+- If there are queued voice instructions, these are replaced with the latest instruction.
+- Update permissions for Android 13 so map tiles can be cached and photos added.

--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleMapFragment.kt
@@ -2,9 +2,8 @@ package net.cyclestreets
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import androidx.preference.PreferenceManager
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
@@ -12,19 +11,22 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
-
 import net.cyclestreets.fragments.R
 import net.cyclestreets.iconics.IconicsHelper
-import net.cyclestreets.util.*
+import net.cyclestreets.util.AsyncDelete
+import net.cyclestreets.util.Logging
 import net.cyclestreets.util.MenuHelper.createMenuItem
 import net.cyclestreets.util.MenuHelper.enableMenuItem
+import net.cyclestreets.util.Theme
+import net.cyclestreets.util.doOrRequestPermission
+import net.cyclestreets.util.requestPermissionsResultAction
 import net.cyclestreets.views.CycleMapView
-
 import org.osmdroid.config.Configuration
 import org.osmdroid.config.DefaultConfigurationProvider
 import org.osmdroid.views.overlay.Overlay
-
 import java.io.File
 import java.util.Date
 
@@ -43,7 +45,8 @@ open class CycleMapFragment : Fragment(), Undoable {
 
         forceMenuRebuild = true
 
-        checkPermissionNoMoreThanOnceEveryFiveMinutes()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+            checkPermissionNoMoreThanOnceEveryFiveMinutes()
 
         map = CycleMapView(context, this.javaClass.name, this)
         searchIcon = IconicsHelper.materialIcon(requireContext(), GoogleMaterial.Icon.gmd_search, Theme.lowlightColorInverse(context))

--- a/libraries/cyclestreets-view/src/main/AndroidManifest.xml
+++ b/libraries/cyclestreets-view/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
@@ -5,16 +5,14 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_DENIED
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
-import android.os.Build
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat.startActivity
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import net.cyclestreets.CycleStreetsPreferences.*
 import net.cyclestreets.GENERIC_PERMISSION_REQUEST
@@ -27,7 +25,7 @@ private val TAG = Logging.getTag(Permissions::class.java)
 // Check for permissions
 fun hasPermission(context: Context?, permission: String): Boolean {
     return if (context != null)
-        context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+        ContextCompat.checkSelfPermission(context, permission) == PERMISSION_GRANTED
     else false
 }
 
@@ -153,7 +151,6 @@ fun requestPermissionsResultAction(grantResult: Int?, permission: String, action
 }
 
 // Go to settings - if dynamic permission requesting is no long an option
-@RequiresApi(api = Build.VERSION_CODES.M)
 private fun goToSettings(context: Context) {
     Log.d(TAG, "Opening Settings screen to allow user to update permissions")
     val androidAppSettingsIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:net.cyclestreets"))
@@ -172,6 +169,7 @@ private fun justification(context: Context, permission: String, justificationFor
 private object Permissions {
     val justifications: Map<String, Int> = hashMapOf(
         Manifest.permission.READ_EXTERNAL_STORAGE to R.string.perm_justification_read_external_storage,
+        // todo - update this :
         Manifest.permission.WRITE_EXTERNAL_STORAGE to R.string.perm_justification_write_external_storage,
         Manifest.permission.ACCESS_FINE_LOCATION to R.string.perm_justification_access_fine_location,
         Manifest.permission.READ_CONTACTS to R.string.perm_justification_read_contacts

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/util/Permissions.kt
@@ -169,7 +169,7 @@ private fun justification(context: Context, permission: String, justificationFor
 private object Permissions {
     val justifications: Map<String, Int> = hashMapOf(
         Manifest.permission.READ_EXTERNAL_STORAGE to R.string.perm_justification_read_external_storage,
-        // todo - update this :
+        Manifest.permission.READ_MEDIA_IMAGES to R.string.perm_justification_read_media_images,
         Manifest.permission.WRITE_EXTERNAL_STORAGE to R.string.perm_justification_write_external_storage,
         Manifest.permission.ACCESS_FINE_LOCATION to R.string.perm_justification_access_fine_location,
         Manifest.permission.READ_CONTACTS to R.string.perm_justification_read_contacts

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Canvas;
 import android.location.Location;
+import android.os.Build;
 import android.os.CountDownTimer;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -71,7 +72,9 @@ public class CycleMapView extends FrameLayout
     super(context);
 
     // Make sure we can save map tiles, regardless of whether we have the write-external permission granted.
-    boolean hasWritePermission = PermissionsKt.hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    boolean hasWritePermission = PermissionsKt.hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            // WRITE_EXTERNAL_STORAGE deprecated in Android 13. Permission not req'd for app-specific storage
+            || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
     Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context));
     Log.i(TAG, "Creating map view. App has write-external permission? " + hasWritePermission +
         "; osmdroid base path: " + Configuration.getInstance().getOsmdroidBasePath().getAbsolutePath() +

--- a/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
+++ b/libraries/cyclestreets-view/src/main/java/net/cyclestreets/views/CycleMapView.java
@@ -72,13 +72,13 @@ public class CycleMapView extends FrameLayout
     super(context);
 
     // Make sure we can save map tiles, regardless of whether we have the write-external permission granted.
-    boolean hasWritePermission = PermissionsKt.hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            // WRITE_EXTERNAL_STORAGE deprecated in Android 13. Permission not req'd for app-specific storage
-            || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU);
+    boolean hasWritePermission = PermissionsKt.hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    // WRITE_EXTERNAL_STORAGE deprecated in Android 13. Permission not req'd for app-specific storage
+    boolean android13Plus = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU;
     Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context));
-    Log.i(TAG, "Creating map view. App has write-external permission? " + hasWritePermission +
-        "; osmdroid base path: " + Configuration.getInstance().getOsmdroidBasePath().getAbsolutePath() +
-        "; osmdroid tile cache location: " + Configuration.getInstance().getOsmdroidTileCache().getAbsolutePath());
+    Log.i(TAG, String.format("Creating map view" + (android13Plus ?";":". App has write-external permission? " + hasWritePermission + ";") +
+            " osmdroid base path: " + Configuration.getInstance().getOsmdroidBasePath().getAbsolutePath() +
+            "; osmdroid tile cache location: " + Configuration.getInstance().getOsmdroidTileCache().getAbsolutePath()));
 
     mapView_ = new MapView(context, TileSource.mapTileProvider(context));
     addView(mapView_);

--- a/libraries/cyclestreets-view/src/main/res/values/strings.xml
+++ b/libraries/cyclestreets-view/src/main/res/values/strings.xml
@@ -161,6 +161,11 @@
       <li>&nbsp; allow you to select photographs from your image library for use in the Add Photo feature.</li>
     </ul>
   ]]></string>
+  <string name="perm_justification_read_media_images" translatable="false"><![CDATA[
+    <ul>
+      <li>&nbsp; allow you to select photographs from your image library for use in the Add Photo feature.</li>
+    </ul>
+  ]]></string>
   <string name="perm_justification_write_external_storage" translatable="false"><![CDATA[
     <ul>
       <li>&nbsp; cache downloaded map tiles <b>(without this the app will function poorly and consume much more data)</b></li>


### PR DESCRIPTION
To fix #542 

I haven't touched the READ permission request in MapPack as I think that isn't working at the moment?  

Write permissions for app-specific storage (i.e. map tiles) is no longer required.  Same for Read permission for app-specific storage (which doesn't seem to get explicitly requested, presumably as it's granted as part of the write permission).  Removed for Android 13 upwards. (CycleMapFragment)
Note that because permission for map tiles is no longer granted, the old cache location won't get removed – I'm not sure if this is an issue?  (See CycleMapFragment.onRequestPermissionsResult)

CycleMapView – I've just changed the log message in here.

Write permission to store photos should be handled by the camera app – removed for Android 13 upwards. (AddPhotoFragment)

Read permission to access photos - changed to READ_MEDIA_IMAGES for Android 13 upwards.

Tested on Pixel 3 API 28 (Android 9) emulator, Fairphone 2 (Android 10), Fairphone 3 (Android 13).

