### PR TITLE
Resetting the OSMDroid tile cache.

### DIFF
--- a/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleStreetsAppSupport.java
+++ b/libraries/cyclestreets-fragments/src/main/java/net/cyclestreets/CycleStreetsAppSupport.java
@@ -10,9 +10,7 @@ import android.content.SharedPreferences;
 import android.util.Log;
 
 public final class CycleStreetsAppSupport {
-
   private static final String TAG = Logging.getTag(CycleStreetsAppSupport.class);
-
   private static boolean isFirstRun;
   private static boolean isNew;
   private static String version;
@@ -86,7 +84,7 @@ public final class CycleStreetsAppSupport {
   private static void migratePreferences(Integer previousVersionCode, Integer versionCode) {
     Log.i(TAG, "Upgrading from " + previousVersion + " (" + previousVersionCode + ") to " + version + " (" + versionCode + ")");
 
-    if (previousVersionCode < 1621 && versionCode >= 1621) {
+    if (previousVersionCode < 1667 && versionCode >= 1667) {
       Log.i(TAG, "Clearing OSMDroid cache location after upgrade to target Android 10 (SDK 29) or higher changed accessible paths");
       CycleStreetsPreferences.clearOsmdroidCacheLocation();
     }


### PR DESCRIPTION
This is relatively drastic, but we've got a number of reports where the app stops drawing tiles when the phone OS has been upgraded. We don't currently detect that situation (which can require a cahce reset), but if we try this on our beta channel we can at least get an idea if it'll help.

If yes, we can do it properly. Otherwise we can roll back.