### PR TITLE
DRAFT: Target SDK Level 34, move to AGP 8.2.2, Kotlin 1.9,20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-  ext.kotlinVersion = '1.9.10'
+  ext.kotlinVersion = '1.9.20'
   repositories {
     google()
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.2.2'
+    classpath 'com.android.tools.build:gradle:8.5.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   }
 }
@@ -34,7 +34,7 @@ ext {
   // Remember to keep these values in sync with .travis.yml
   compileSdkVersion=34
   minSdkVersion=23
-  targetSdkVersion=33
+  targetSdkVersion=34
 
   // java version
   javaVersion = JavaVersion.VERSION_11

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -89,8 +89,8 @@ dependencies {
   api project(':libraries:cyclestreets-fragments')
   implementation 'androidx.startup:startup-runtime:1.1.1'
 
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test:rules:1.5.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test:rules:1.6.1'
   androidTestImplementation "org.assertj:assertj-core:${rootProject.ext.assertjVersion}"
 }

--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'me.moallemi.advanced-build-version'
 advancedVersioning {
   nameOptions {
     versionMajor 3
-    versionMinor 12
+    versionMinor 13
     versionPatch 0
   }
   codeOptions {

--- a/cyclestreets.app/src/androidTest/java/net/cyclestreets/content/DatabaseUpgradeTest.java
+++ b/cyclestreets.app/src/androidTest/java/net/cyclestreets/content/DatabaseUpgradeTest.java
@@ -40,7 +40,7 @@ public class DatabaseUpgradeTest {
       Log.d(TAG, "Testing upgrade from version:" + i);
       copyDatabase(i);
 
-      DatabaseHelper databaseHelper = new DatabaseHelper(InstrumentationRegistry.getTargetContext());
+      DatabaseHelper databaseHelper = new DatabaseHelper(InstrumentationRegistry.getInstrumentation().getTargetContext());
       Log.d(TAG, " New Database Version:" + databaseHelper.getWritableDatabase().getVersion());
       Assert.assertEquals(DatabaseHelper.DATABASE_VERSION, databaseHelper.getWritableDatabase().getVersion());
       logTableContents(databaseHelper.getReadableDatabase(), ROUTE_TABLE_OLD);
@@ -55,10 +55,10 @@ public class DatabaseUpgradeTest {
   }
 
   private void copyDatabase(int version) throws IOException {
-    String dbPath = InstrumentationRegistry.getTargetContext().getDatabasePath(DatabaseHelper.DATABASE_NAME).getAbsolutePath();
+    String dbPath = InstrumentationRegistry.getInstrumentation().getTargetContext().getDatabasePath(DatabaseHelper.DATABASE_NAME).getAbsolutePath();
 
     String dbName = String.format("cyclestreets_v%d.db", version);
-    InputStream mInput = InstrumentationRegistry.getContext().getAssets().open(dbName);
+    InputStream mInput = InstrumentationRegistry.getInstrumentation().getContext().getAssets().open(dbName);
 
     File db = new File(dbPath);
     if (db.exists()) {

--- a/cyclestreets.app/src/main/assets/whatsnew.html
+++ b/cyclestreets.app/src/main/assets/whatsnew.html
@@ -6,7 +6,11 @@
   -->
 
 <h3>Release 3.12</h3>
-<i>There are no new features in this release. We are updated a number of our
+<i>There are no new features in this release. We have updated some of our
+  dependencies.</i>
+
+<h3>Release 3.12</h3>
+<i>There are no new features in this release. We have updated a number of our
 dependencies, including our underlying maps display.</i>
 <li>POI issue fixed.</li>
 

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,3 +1,2 @@
-There are no new features in this release. We are updated a number of our
-dependencies, including our underlying maps display.
-POI issue fixed.
+There are no new features in this release. We have updated some of our
+dependencies.

--- a/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
+++ b/cyclestreets.app/src/main/play/release-notes/en-GB/production.txt
@@ -1,2 +1,0 @@
-There are no new features in this release. We are updated a number of our
-dependencies, including our underlying maps display.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/libraries/cyclestreets-core/build.gradle
+++ b/libraries/cyclestreets-core/build.gradle
@@ -15,7 +15,7 @@ configurations {
 dependencies {
   api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-  implementation 'androidx.core:core:1.12.0'
+  implementation 'androidx.core:core:1.13.1'
   implementation 'androidx.preference:preference:1.2.1'
 
   api "org.osmdroid:osmdroid-android:${rootProject.ext.osmdroidVersion}"


### PR DESCRIPTION
Our mandated move to targetting SDK level 34, and the associated tools and library bumps. 

Closes #557 