### PR TITLE
Draft rather than publish new release

### DIFF
--- a/cyclestreets.app/build.gradle
+++ b/cyclestreets.app/build.gradle
@@ -75,11 +75,13 @@ android {
   namespace 'net.cyclestreets'
 }
 
+import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 play {
   // credentials file decrypted from play-api-key.json.enc by ciLicense.sh
   serviceAccountCredentials.set(file('play-api-key.json'))
 
   track.set('beta')
+  releaseStatus.set(ReleaseStatus.IN_PROGRESS)
 
   // If you want to update screenshots etc, check what 'publish' tasks are available by running
   // `./gradlew tasks`, and refer to the documentation at https://github.com/Triple-T/gradle-play-publisher


### PR DESCRIPTION
We need to edit the declared permissions, so we need to create the new release as a draft. 

I don't think I have the signing keys any more, so need to get the Travis build to create the artifact, upload it, but not try to push it out. Once that's done, I can update the permissions in the Play Console, revert this change, and, hopefully we can all relax again until we get pushed into this upgrade dance again this time next year.